### PR TITLE
Preprocessor directives and other

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1062,11 +1062,11 @@ module.exports = grammar({
     _case_branch_body: ($) =>
       prec(1, choice($.do_block, field("statement", $._statement))),
 
-    case_conditon: ($) =>
+    case_condition: ($) =>
       seq(optional(seq(kw("OR"), kw("WHEN"))), $._expression),
 
     case_when_branch: ($) =>
-      seq(kw("WHEN"), repeat($.case_conditon), kw("THEN"), $._case_branch_body),
+      seq(kw("WHEN"), repeat($.case_condition), kw("THEN"), $._case_branch_body),
     case_otherwise_branch: ($) => seq(kw("OTHERWISE"), $._case_branch_body),
 
     case_body: ($) =>
@@ -1682,6 +1682,7 @@ function _list(rule, separator) {
 }
 
 function kw(keyword) {
+  throw new Error(keyword);
   if (keyword.toUpperCase() != keyword) {
     throw new Error(`Expected upper case keyword got ${keyword}`);
   }

--- a/grammar.js
+++ b/grammar.js
@@ -82,7 +82,7 @@ module.exports = grammar({
     string_literal: ($) => $._escaped_string,
 
     date_literal: ($) => /\d{1,2}\/\d{1,2}\/\d{4}|\d{2}/,
-    array_literal: ($) => seq("[", optional(_list($._expression, ",")), "]"),
+    array_literal: ($) => seq("[", optional(choice($.range_notation, _list($._expression, ","))), "]"),
 
     double_quoted_string: ($) =>
       seq('"', repeat(choice(/[^"\\]+/, /\\./, $._special_character)), '"'),
@@ -193,14 +193,13 @@ module.exports = grammar({
         $.logical_expression
       ),
 
+    range_notation: ($) => seq($._expression, kw("FOR"), $._expression),
     array_access: ($) =>
       prec.right(
         1,
         seq(
           field("array", choice($.identifier, $.object_access)),
-          "[",
-          $._expression,
-          "]"
+          $.array_literal,
         )
       ),
 
@@ -1368,7 +1367,7 @@ module.exports = grammar({
           choice($.scope_tuning, $.access_tuning, $.serialization_tuning)
         ),
         alias(choice($._type, $.string_literal), $.type_tuning),
-        optional(seq("[", optional(field("size", $.number_literal)), "]")),
+        optional(field("size", $.array_literal)),
         repeat(seq($.variable, optional(","))),
         $._terminator
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -1682,7 +1682,6 @@ function _list(rule, separator) {
 }
 
 function kw(keyword) {
-  throw new Error(keyword);
   if (keyword.toUpperCase() != keyword) {
     throw new Error(`Expected upper case keyword got ${keyword}`);
   }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2,14 +2,22 @@
 #include <wctype.h>
 #include <stdio.h>
 
+bool match_keyword(TSLexer *lexer, const char *keyword, TSSymbol symbol);
+
 enum TokenType {
   NAMEDOT,
   NAMECOLON,
   NAMEDOUBLECOLON,
   OR_OPERATOR,
-  AND_OPERATOR, 
+  AND_OPERATOR,
   AUGMENTED_ASSIGNMENT,
   ESCAPED_STRING,
+  INPUT_KEYWORD,
+  OUTPUT_KEYWORD,
+  NEW_KEYWORD,
+  OLD_KEYWORD,
+  FOR_KEYWORD,
+  DEF_KEYWORD
 };
 
 void *tree_sitter_abl_external_scanner_create() {
@@ -69,35 +77,22 @@ bool tree_sitter_abl_external_scanner_scan(
     }
   }
 
-  if (valid_symbols[OR_OPERATOR] || valid_symbols[AND_OPERATOR] || valid_symbols[AUGMENTED_ASSIGNMENT]) {
+  if (valid_symbols[OR_OPERATOR] && match_keyword(lexer, "OR", OR_OPERATOR)) return true;
+  if (valid_symbols[AND_OPERATOR] && match_keyword(lexer, "AND", AND_OPERATOR)) return true;
+
+  if (valid_symbols[INPUT_KEYWORD] && match_keyword(lexer, "INPUT", INPUT_KEYWORD)) return true;
+  if (valid_symbols[OUTPUT_KEYWORD] && match_keyword(lexer, "OUTPUT", OUTPUT_KEYWORD)) return true;
+  if (valid_symbols[NEW_KEYWORD] && match_keyword(lexer, "NEW", NEW_KEYWORD)) return true;
+  if (valid_symbols[OLD_KEYWORD] && match_keyword(lexer, "OLD", OLD_KEYWORD)) return true;
+  if (valid_symbols[FOR_KEYWORD] && match_keyword(lexer, "FOR", FOR_KEYWORD)) return true;
+  if (valid_symbols[DEF_KEYWORD] && match_keyword(lexer, "DEF", DEF_KEYWORD)) return true;
+
+  if (valid_symbols[AUGMENTED_ASSIGNMENT]) {
     while (!lexer->eof(lexer) && iswspace(lexer->lookahead)) {
       lexer->advance(lexer, true);
     }
 
-    if (!lexer->eof(lexer) && insensitive_equals(lexer->lookahead, 'O')) {
-      lexer->advance(lexer, false);
-      if (!lexer->eof(lexer) && insensitive_equals(lexer->lookahead, 'R')) {
-        lexer->advance(lexer, false);
-        if (!lexer->eof(lexer) && iswspace(lexer->lookahead)) {
-          lexer->result_symbol = OR_OPERATOR;
-          return true;
-        }
-      }
-    }
-    else if (!lexer->eof(lexer) && insensitive_equals(lexer->lookahead, 'A')) {
-      lexer->advance(lexer, false);
-      if (!lexer->eof(lexer) && insensitive_equals(lexer->lookahead, 'N')) {
-        lexer->advance(lexer, false);
-        if (!lexer->eof(lexer) && insensitive_equals(lexer->lookahead,'D')) {
-          lexer->advance(lexer, false);
-          if (!lexer->eof(lexer) && iswspace(lexer->lookahead)) {
-            lexer->result_symbol = AND_OPERATOR;
-            return true;
-          }
-        }
-      }
-    }
-    else if (!lexer->eof(lexer) && (lexer->lookahead == '+' || lexer->lookahead == '-' || lexer->lookahead == '*' || lexer->lookahead == '/' )) {
+    if (!lexer->eof(lexer) && (lexer->lookahead == '+' || lexer->lookahead == '-' || lexer->lookahead == '*' || lexer->lookahead == '/' )) {
       lexer->advance(lexer, false);
       if (!lexer->eof(lexer) && insensitive_equals(lexer->lookahead, '=')) {
         lexer->advance(lexer, false);
@@ -116,7 +111,7 @@ bool tree_sitter_abl_external_scanner_scan(
     while (!lexer->eof(lexer) && lexer->lookahead != start) {
       if (lexer->lookahead == '~') {
         lexer->advance(lexer, false);
-        if (!lexer->eof(lexer)) 
+        if (!lexer->eof(lexer))
           lexer->advance(lexer, false);
       }
       else lexer->advance(lexer, false);
@@ -131,4 +126,34 @@ bool tree_sitter_abl_external_scanner_scan(
 
   return false;
 }
+
+bool match_keyword(TSLexer *lexer, const char *keyword, TSSymbol symbol) {
+  while (!lexer->eof(lexer) && iswspace(lexer->lookahead)) {
+      lexer->advance(lexer, true);
+  }
+
+  const char *k = keyword;
+  TSLexer checkpoint = *lexer;
+
+  while (*k) {
+      if (lexer->eof(lexer) || !insensitive_equals(lexer->lookahead, *k)) {
+          *lexer = checkpoint;
+          return false;
+      }
+      lexer->advance(lexer, false);
+      k++;
+  }
+
+  if (lexer->eof(lexer) || iswspace(lexer->lookahead) ||
+      lexer->lookahead == '(' || lexer->lookahead == '.' || lexer->lookahead == ':' ||
+      lexer->lookahead == ',') {
+
+      lexer->result_symbol = symbol;
+      return true;
+  }
+
+  *lexer = checkpoint;
+  return false;
+}
+
 

--- a/test/corpus/basic.txt
+++ b/test/corpus/basic.txt
@@ -2770,9 +2770,9 @@ Preprocessor Directives
 ================================================================================
 
 &if DEFINED(is_Running) <> 0 &THEN
-DEFINE VARIABLE cParm AS CHARACTER.
+  DEFINE VARIABLE cParm AS CHARACTER.
 &ELSE
-DEFINE INPUT PARAMETER cParm AS CHARACTER.
+  DEFINE INPUT PARAMETER cParm AS CHARACTER.
 &ENDIF
 
 &Scoped-define OPEN-QUERY-DEFAULT-FRAME OPEN QUERY DEFAULT-FRAME FOR EACH ITEM ~

--- a/test/corpus/basic.txt
+++ b/test/corpus/basic.txt
@@ -47,7 +47,7 @@ DISPLAY {&VAR1}.
     (include_argument
       (identifier))
     (include_argument
-      (double_quoted_string))
+      (string_literal))
     (include_argument
       (identifier)
       (identifier)))
@@ -2764,3 +2764,26 @@ END ENUM.
           (identifier))
         (enum_member
           (identifier))))))
+
+================================================================================
+Preprocessor Directives
+================================================================================
+
+&if DEFINED(is_Running) <> 0 &THEN
+DEFINE VARIABLE cParm AS CHARACTER.
+&ELSE
+DEFINE INPUT PARAMETER cParm AS CHARACTER.
+&ENDIF
+
+&Scoped-define OPEN-QUERY-DEFAULT-FRAME OPEN QUERY DEFAULT-FRAME FOR EACH ITEM ~
+      WHERE item.system_id = ipcItemSysid AND ~
+item.item = ipcItem NO-LOCK.
+&Scoped-define TABLES-IN-QUERY-DEFAULT-FRAME ITEM
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (preprocessor_directive)
+  (preprocessor_directive)
+  (preprocessor_directive))
+

--- a/test/corpus/basic.txt
+++ b/test/corpus/basic.txt
@@ -1859,7 +1859,7 @@ END CASE.
     (identifier)
     (body
       (case_when_branch
-        (case_conditon
+        (case_condition
           (string_literal))
         (do_block
           (body
@@ -1874,11 +1874,11 @@ END CASE.
                 (assignment_operator)
                 (number_literal))))))
       (case_when_branch
-        (case_conditon
+        (case_condition
           (logical_expression
             (string_literal)
             (identifier)))
-        (case_conditon
+        (case_condition
           (string_literal))
         (variable_assignment
           (assignment
@@ -1886,7 +1886,7 @@ END CASE.
             (assignment_operator)
             (number_literal))))
       (case_when_branch
-        (case_conditon
+        (case_condition
           (string_literal))
         (variable_assignment
           (assignment

--- a/test/corpus/basic.txt
+++ b/test/corpus/basic.txt
@@ -1361,7 +1361,8 @@ oObject:Length -= String(pcMessage):Size.
       array: (object_access
         object: (identifier)
         property: (identifier))
-      (number_literal)))
+      (array_literal
+        (number_literal))))
   (variable_assignment
     (assignment
       name: (object_access
@@ -1769,7 +1770,6 @@ CLASS r-CustObj FINAL:
 
 
 END CLASS.
-
 
 --------------------------------------------------------------------------------
 
@@ -2355,7 +2355,8 @@ var List<Ant> ListOfAnts.
   (var_statement
     (type_tuning
       (primitive_type))
-    (number_literal)
+    (array_literal
+      (number_literal))
     (variable
       (assignment
         (identifier)
@@ -2377,6 +2378,7 @@ var List<Ant> ListOfAnts.
   (var_statement
     (type_tuning
       (primitive_type))
+    (array_literal)
     (variable
       (identifier))
     (variable
@@ -2419,7 +2421,8 @@ var List<Ant> ListOfAnts.
   (var_statement
     (type_tuning
       (identifier))
-    (number_literal)
+    (array_literal
+      (number_literal))
     (variable
       (identifier)))
   (comment)
@@ -2526,7 +2529,8 @@ var List<Ant> ListOfAnts.
   (var_statement
     (type_tuning
       (identifier))
-    (number_literal)
+    (array_literal
+      (number_literal))
     (variable
       (assignment
         (identifier)
@@ -2546,6 +2550,7 @@ var List<Ant> ListOfAnts.
   (var_statement
     (type_tuning
       (identifier))
+    (array_literal)
     (variable
       (assignment
         (identifier)
@@ -2590,6 +2595,7 @@ var List<Ant> ListOfAnts.
   (var_statement
     (type_tuning
       (primitive_type))
+    (array_literal)
     (variable
       (assignment
         (identifier)
@@ -2642,13 +2648,14 @@ RUN server-error.p ON SERVER hServer
         (argument
           (array_access
             (identifier)
-            (function_call
-              (identifier)
-              (arguments
-                (argument
-                  (string_literal))
-                (argument
-                  (identifier)))))))))
+            (array_literal
+              (function_call
+                (identifier)
+                (arguments
+                  (argument
+                    (string_literal))
+                  (argument
+                    (identifier))))))))))
   (run_statement
     (identifier)
     (run_tuning


### PR DESCRIPTION
Fixes:
1. Added parsing of preprocessor directives (https://github.com/usagi-coffee/tree-sitter-abl/issues/88)
2. Adjusted array parsing (https://github.com/usagi-coffee/tree-sitter-abl/issues/107)
3. Partial fix for keywords splitting up identifiers. Probably not the best solution, but at least for now it works. At the moment added ones, that I had in examples, perhaps will have more later (https://github.com/usagi-coffee/tree-sitter-abl/issues/53)
4. Adjusted string parsing to support attributes (https://github.com/BalticAmadeus/AblFormatter/issues/216)
5. Few other minor adjustments in grammar

Please update version to 0.0.46 if possible