### PR TITLE
grammar: accept five documented keyword abbreviations

### DIFF
--- a/grammar/core/common.js
+++ b/grammar/core/common.js
@@ -286,7 +286,7 @@ export default ({ kw }) => ({
 
   _aggregate_label_phrase: ($) => seq(kw("LABEL"), field("label", $.string_literal)),
   _initial_value: ($) => choice($._expression, seq("[", optional($._expressions), "]")),
-  _parameter_direction: ($) => choice(kw("INPUT"), kw("OUTPUT"), kw("INPUT-OUTPUT")),
+  _parameter_direction: ($) => choice(kw("INPUT"), kw("OUTPUT"), kw("INPUT-OUTPUT", { offset: 7 })),
 
   _alert_box_options: ($) =>
     choice(

--- a/grammar/statements/for.js
+++ b/grammar/statements/for.js
@@ -16,9 +16,9 @@ export default ({ kw }) => ({
     choice(
       seq(
         alias($.__for_while_phrase, $.while_phrase),
-        optional(alias(kw("TRANSACTION"), $.transaction)),
+        optional(alias(kw("TRANSACTION", { offset: 5 }), $.transaction)),
       ),
-      alias(kw("TRANSACTION"), $.transaction),
+      alias(kw("TRANSACTION", { offset: 5 }), $.transaction),
     ),
   __for_record_or_variables: ($) => choice($.__for_record_phrase_section, $._loop_phrase),
   __for_record_phrase_section: ($) =>

--- a/grammar/statements/input-output.js
+++ b/grammar/statements/input-output.js
@@ -1,7 +1,7 @@
 export default ({ kw }) => ({
   input_output_statement: ($) => seq($.__input_output_prefix, $.__input_output_body, $._terminator),
 
-  __input_output_prefix: ($) => seq(kw("INPUT-OUTPUT"), optional($._stream_phrase)),
+  __input_output_prefix: ($) => seq(kw("INPUT-OUTPUT", { offset: 7 }), optional($._stream_phrase)),
   __input_output_body: ($) =>
     choice(
       alias(kw("CLOSE"), $.close),

--- a/grammar/statements/parameter.js
+++ b/grammar/statements/parameter.js
@@ -81,7 +81,7 @@ export default ({ kw }) => ({
           $._format_string,
           seq(kw("COLUMN-LABEL"), field("column_label", $.string_literal)),
           seq(kw("DECIMALS"), field("decimals", $.number_literal)),
-          seq(kw("INITIAL"), field("initial", $._initial_value)),
+          seq(kw("INITIAL", { offset: 4 }), field("initial", $._initial_value)),
           seq(
             kw("LABEL"),
             field("label", $.string_literal),

--- a/grammar/statements/put-cursor.js
+++ b/grammar/statements/put-cursor.js
@@ -8,7 +8,7 @@ export default ({ kw }) => ({
         kw("OFF"),
         seq(
           optional(seq(kw("ROW"), field("row", $._expression))),
-          optional(seq(kw("COLUMN"), field("column", $._expression))),
+          optional(seq(kw("COLUMN", { offset: 3 }), field("column", $._expression))),
         ),
       ),
     ),

--- a/grammar/statements/query.js
+++ b/grammar/statements/query.js
@@ -29,7 +29,7 @@ export default ({ kw }) => ({
     ),
   __query_field_list: ($) =>
     choice(seq($.__query_fields_list, optional($.__query_except_list)), $.__query_except_list),
-  __query_fields_list: ($) => seq(kw("FIELDS"), $.__query_parenthesized_field_names),
+  __query_fields_list: ($) => seq(kw("FIELDS", { offset: 5 }), $.__query_parenthesized_field_names),
   __query_except_list: ($) => seq(kw("EXCEPT"), $.__query_parenthesized_field_names),
   __query_parenthesized_field_names: ($) => seq("(", optional($.__query_field_names), ")"),
   __query_field_names: ($) =>

--- a/test/corpus/statements/for.txt
+++ b/test/corpus/statements/for.txt
@@ -753,3 +753,22 @@ END.
         record: (qualified_name
           left: (identifier)
           right: (identifier))))))
+
+================================================================================
+FOR - TRANS abbreviation
+================================================================================
+
+FOR EACH cust TRANS:
+  DISPLAY cust.
+END.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (for_statement
+    (record_phrase
+      record: (identifier))
+    (transaction)
+    (body
+      (display_statement
+        record: (identifier)))))

--- a/test/corpus/statements/parameter.txt
+++ b/test/corpus/statements/parameter.txt
@@ -837,3 +837,22 @@ DEFINE INPUT PARAMETER x AS INTEGER INIT 1 NO-UNDO.
     type: (identifier)
     initial: (number_literal)
     (no_undo)))
+
+================================================================================
+DEFINE PARAMETER - INPUT-OUTPUT abbreviation
+================================================================================
+
+DEFINE INPUT-O PARAMETER x AS INTEGER NO-UNDO.
+DEFINE INPUT-OUTPUT PARAMETER y AS INTEGER NO-UNDO.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (parameter_definition
+    name: (identifier)
+    type: (identifier)
+    (no_undo))
+  (parameter_definition
+    name: (identifier)
+    type: (identifier)
+    (no_undo)))

--- a/test/corpus/statements/parameter.txt
+++ b/test/corpus/statements/parameter.txt
@@ -822,3 +822,18 @@ DEFINE INPUT PARAMETER pExtent0 AS INTEGER EXTENT 0.
     type: (identifier)
     (extent_phrase
       size: (number_literal))))
+
+================================================================================
+DEFINE PARAMETER - INIT abbreviation
+================================================================================
+
+DEFINE INPUT PARAMETER x AS INTEGER INIT 1 NO-UNDO.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (parameter_definition
+    name: (identifier)
+    type: (identifier)
+    initial: (number_literal)
+    (no_undo)))

--- a/test/corpus/statements/put-cursor.txt
+++ b/test/corpus/statements/put-cursor.txt
@@ -39,3 +39,16 @@ PUT CURSOR ROW iRow + 1 COLUMN iCol - 1.
     column: (binary_expression
       (identifier)
       (number_literal))))
+
+================================================================================
+PUT CURSOR - COL abbreviation
+================================================================================
+
+PUT CURSOR ROW 5 COL 10.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (put_cursor_statement
+    row: (number_literal)
+    column: (number_literal)))

--- a/test/corpus/statements/query.txt
+++ b/test/corpus/statements/query.txt
@@ -647,3 +647,19 @@ DEFINE QUERY qExceptAll FOR Customer EXCEPT ().
     (query_table_list
       table: (identifier)
       (field_list))))
+
+================================================================================
+DEFINE QUERY - FIELD abbreviation
+================================================================================
+
+DEFINE QUERY q FOR cust FIELD (name).
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (query_definition
+    name: (identifier)
+    (query_table_list
+      table: (identifier)
+      (field_list
+        (identifier)))))


### PR DESCRIPTION
First of the PRs discussed in #118. Five keyword abbreviations that ABL documents but the grammar did not accept, each as its own commit with its corpus test.

| Keyword | Accepted from | Site |
|---|---|---|
| `TRANSACTION` | `TRANS` | `FOR` while/transaction tail |
| `COLUMN` | `COL` | `PUT CURSOR` |
| `FIELDS` | `FIELD` | query field list |
| `INITIAL` | `INIT` | parameter definition |
| `INPUT-OUTPUT` | `INPUT-O` | `_parameter_direction` + `INPUT-OUTPUT` statement |

### One note on the last commit

It touches two files on purpose. Applying the offset to `_parameter_direction` alone leaves the `INPUT-OUTPUT` statement keyword in `input-output.js` as a second, differently shaped token matching the same text; the lexer then picks the wrong one in argument position and `RUN p (INPUT-OUTPUT DATASET ds)` gains an `ERROR` node. Six existing tests caught this. Moving both sites together keeps a single token shape, and matches ABL abbreviations being global rather than per-statement.

`_parameter_direction` is shared by `class`, `event`, `function`, `parameter`, `run-stored-procedure` and two sites in `grammar.js`, so routine parameters are covered everywhere.

### Numbers

| | before | after | delta |
|---|---|---|---|
| `ACTION_COUNT` | 37 735 | 37 717 | **−18** |
| `STATE_COUNT` | 29 576 | 29 581 | +5 |
| `LARGE_STATE_COUNT` | 13 627 | 13 682 | +55 |
| `src/parser.c` | 105.71 MiB | 105.91 MiB | +0.19 MiB |

Corpus: **1071 passing, 0 failing**.

No generated files are included — `src/parser.c`, `src/grammar.json` and `src/node-types.json` are untouched, matching how grammar commits land here.
