### PR TITLE
grammar: 35 real-world fixes, including three silent misparses

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -494,7 +494,7 @@ export default grammar({
             field("name", $._expression),
           ),
           optional(seq(kw("AS"), field("type", $._type_name))),
-          optional(kw("BY-REFERENCE")),
+          optional(choice(kw("BY-REFERENCE"), kw("BY-VALUE"), kw("APPEND"), kw("BIND"))),
         ),
 
       function_call: ($) =>

--- a/grammar/core/common.js
+++ b/grammar/core/common.js
@@ -297,7 +297,8 @@ export default ({ kw }) => ({
     ),
   _alert_box_after_type: ($) =>
     choice(seq($._alert_buttons_phrase, optional($._alert_box_title)), $._alert_box_title),
-  _alert_box_title: ($) => seq(kw("TITLE"), field("title", $.string_literal)),
+  _alert_box_title: ($) =>
+    seq(kw("TITLE"), field("title", choice($.string_literal, $._identifier_or_qualified_name))),
   _alert_type: ($) =>
     choice(
       kw("MESSAGE"),

--- a/grammar/core/common.js
+++ b/grammar/core/common.js
@@ -8,7 +8,8 @@ export default ({ kw }) => ({
     ),
 
   _in_widget_pool: ($) => seq(kw("IN"), kw("WIDGET-POOL"), field("pool", $.identifier)),
-  _handle_in_widget_pool: ($) => seq(field("handle", $.identifier), optional($._in_widget_pool)),
+  _handle_in_widget_pool: ($) =>
+    seq(field("handle", $._identifier_or_array_access), optional($._in_widget_pool)),
 
   _except_fields: ($) => seq(kw("EXCEPT"), repeat1(field("except", $.identifier))),
   _map_phrase: ($) =>

--- a/grammar/core/common.js
+++ b/grammar/core/common.js
@@ -7,7 +7,8 @@ export default ({ kw }) => ({
       seq(kw("LIKE"), field("like", $._identifier_or_qualified_name)),
     ),
 
-  _in_widget_pool: ($) => seq(kw("IN"), kw("WIDGET-POOL"), field("pool", $.identifier)),
+  _in_widget_pool: ($) =>
+    seq(kw("IN"), kw("WIDGET-POOL"), field("pool", choice($.identifier, $.string_literal))),
   _handle_in_widget_pool: ($) =>
     seq(field("handle", $._identifier_or_array_access), optional($._in_widget_pool)),
 

--- a/grammar/expressions/dataset.js
+++ b/grammar/expressions/dataset.js
@@ -3,6 +3,7 @@ export default ({ kw }) => ({
     seq(
       $.__dataset_expression_prefix,
       field("dataset", choice($.object_access, $._identifier_or_qualified_name)),
+      optional($.arguments),
     ),
   __dataset_expression_prefix: ($) => kw("DATASET"),
 });

--- a/grammar/phrases/combo-box.js
+++ b/grammar/phrases/combo-box.js
@@ -2,9 +2,10 @@ export default ({ kw }) => ({
   combo_box_phrase: ($) =>
     seq(
       field("widget", kw("COMBO-BOX")),
-      optional(choice($._list_items_phrase, $._list_item_pairs_phrase)),
       repeat(
         choice(
+          $._list_items_phrase,
+          $._list_item_pairs_phrase,
           seq(kw("INNER-LINES"), field("inner_lines", $.number_literal)),
           $.size_phrase,
           alias(kw("SORT"), $.sort),

--- a/grammar/phrases/format.js
+++ b/grammar/phrases/format.js
@@ -146,14 +146,18 @@ export default ({ kw }) => ({
       ")",
     ),
 
+  __format_view_as_tail: ($) =>
+    prec.right(choice(seq($.size_phrase, optional($._tooltip_phrase)), $._tooltip_phrase)),
   _format_view_as: ($) =>
-    seq(
-      kw("VIEW-AS"),
-      choice(
-        kw("TEXT"),
-        kw("TOGGLE-BOX"),
-        alias($.__format_editor_phrase, $.editor_phrase),
-        alias($.__view_as_alert_box, $.view_as_phrase),
+    prec.right(
+      seq(
+        kw("VIEW-AS"),
+        choice(
+          seq(kw("TEXT"), optional($.__format_view_as_tail)),
+          seq(kw("TOGGLE-BOX"), optional($.__format_view_as_tail)),
+          alias($.__format_editor_phrase, $.editor_phrase),
+          alias($.__view_as_alert_box, $.view_as_phrase),
+        ),
       ),
     ),
 });

--- a/grammar/phrases/format.js
+++ b/grammar/phrases/format.js
@@ -155,6 +155,7 @@ export default ({ kw }) => ({
         choice(
           seq(kw("TEXT"), optional($.__format_view_as_tail)),
           seq(kw("TOGGLE-BOX"), optional($.__format_view_as_tail)),
+          seq(kw("FILL-IN"), optional(kw("NATIVE")), optional($.__format_view_as_tail)),
           alias($.__format_editor_phrase, $.editor_phrase),
           alias($.__view_as_alert_box, $.view_as_phrase),
         ),

--- a/grammar/phrases/trigger.js
+++ b/grammar/phrases/trigger.js
@@ -49,6 +49,7 @@ export default ({ kw }) => ({
       kw("RUN"),
       field("procedure", $._expression),
       optional($.__persistent_trigger_tail),
+      optional($._terminator_dot),
     ),
   __persistent_trigger_tail: ($) =>
     choice(

--- a/grammar/precedences/binary.js
+++ b/grammar/precedences/binary.js
@@ -1,4 +1,4 @@
-// References: EXPORT statement; MESSAGE statement; DISPLAY statement; Format phrase; SIZE phrase;
+// References: EXPORT statement; MESSAGE statement; DISPLAY statement; Format phrase; SIZE phrase; TOOLTIP phrase;
 // SYSTEM-DIALOG GET-FILE statement; CASE statement; Frame phrase; Color/font options; AT phrase.
 // Purpose: allow full binary expressions inside statement/phrase expression slots.
 // Example: EXPORT a - b.
@@ -42,6 +42,7 @@ export default ($) => [
     $._color_font_option,
     $.__frame_head_item,
     $.size_phrase,
+    $._tooltip_phrase,
     $.__system_dialog_filters_pairs,
     $.__system_dialog_filter_pair,
     $.__at_column_row,

--- a/grammar/statements/buffer-copy.js
+++ b/grammar/statements/buffer-copy.js
@@ -30,5 +30,6 @@ export default ({ kw }) => ({
       field("left", $._assignable),
       choice("=", "+=", "-=", "*=", "/="),
       field("right", $._expression),
+      optional(seq(kw("WHEN"), field("when", $._expression))),
     ),
 });

--- a/grammar/statements/case.js
+++ b/grammar/statements/case.js
@@ -6,7 +6,9 @@ export default ({ kw }) => ({
       kw("CASE"),
       $._expression,
       alias($._colon, ":"),
-      repeat1($.case_when_phrase),
+      repeat1(
+        choice($.case_when_phrase, alias($.include_statement, $.include_file_reference)),
+      ),
       optional($.case_otherwise_phrase),
       kw("END"),
       optional(kw("CASE")),

--- a/grammar/statements/catch.js
+++ b/grammar/statements/catch.js
@@ -5,7 +5,7 @@ export default ({ kw }) => ({
     seq(
       kw("CATCH"),
       field("name", $.identifier),
-      optional(seq(kw("AS"), optional(kw("CLASS")), field("type", $.qualified_name))),
+      optional(seq(kw("AS"), optional(kw("CLASS")), field("type", $._identifier_or_qualified_name))),
       $.body,
       kw("END"),
       optional(kw("CATCH")),

--- a/grammar/statements/class.js
+++ b/grammar/statements/class.js
@@ -128,7 +128,7 @@ export default ({ kw }) => ({
     seq($.__class_compound_body, optional(choice(kw("CONSTRUCTOR"), kw("METHOD"))), $._terminator),
 
   __class_destructor_body: ($) =>
-    seq($.__class_compound_body, optional(kw("DESTRUCTOR")), $._terminator),
+    seq($.__class_compound_body, optional(choice(kw("DESTRUCTOR"), kw("METHOD"))), $._terminator),
   __class_compound_body: ($) => seq(repeat($._statement), kw("END")),
 
   __class_destructor_parameters: ($) => seq("(", ")"),

--- a/grammar/statements/class.js
+++ b/grammar/statements/class.js
@@ -139,11 +139,13 @@ export default ({ kw }) => ({
       repeat1(
         choice(
           seq(
+            optional($.__class_property_accessor_modifier),
             kw("GET"),
             optional($.__class_property_accessor_parameters),
             $.__class_property_accessor_tail,
           ),
           seq(
+            optional($.__class_property_accessor_modifier),
             kw("SET"),
             optional($.__class_property_accessor_parameters),
             $.__class_property_accessor_tail,
@@ -175,6 +177,14 @@ export default ({ kw }) => ({
       seq($.__class_property_accessor_body, optional(choice(kw("GET"), kw("SET"))), $._terminator),
     ),
 
+  __class_property_accessor_modifier: ($) =>
+    choice(
+      alias(kw("PRIVATE"), $.access_modifier),
+      alias(kw("PACKAGE-PRIVATE"), $.access_modifier),
+      alias(kw("PROTECTED"), $.access_modifier),
+      alias(kw("PACKAGE-PROTECTED"), $.access_modifier),
+      alias(kw("PUBLIC"), $.access_modifier),
+    ),
   __class_property_accessor_parameters: ($) =>
     choice(seq("(", ")"), $.property_set_parameter_list),
   property_set_parameter_list: ($) => seq("(", $.property_set_parameter, ")"),

--- a/grammar/statements/class.js
+++ b/grammar/statements/class.js
@@ -35,6 +35,7 @@ export default ({ kw }) => ({
           $.method_definition,
           $.constructor_definition,
           $.destructor_definition,
+          $.error_scope_statement,
           $.on_statement,
           $.using_statement,
           $.annotation,

--- a/grammar/statements/class.js
+++ b/grammar/statements/class.js
@@ -138,8 +138,16 @@ export default ({ kw }) => ({
       $.__class_property_definition_prefix,
       repeat1(
         choice(
-          seq(kw("GET"), $.__class_property_accessor_tail),
-          seq(kw("SET"), optional($.property_set_parameter_list), $.__class_property_accessor_tail),
+          seq(
+            kw("GET"),
+            optional($.__class_property_accessor_parameters),
+            $.__class_property_accessor_tail,
+          ),
+          seq(
+            kw("SET"),
+            optional($.__class_property_accessor_parameters),
+            $.__class_property_accessor_tail,
+          ),
         ),
       ),
     ),
@@ -167,6 +175,8 @@ export default ({ kw }) => ({
       seq($.__class_property_accessor_body, optional(choice(kw("GET"), kw("SET"))), $._terminator),
     ),
 
+  __class_property_accessor_parameters: ($) =>
+    choice(seq("(", ")"), $.property_set_parameter_list),
   property_set_parameter_list: ($) => seq("(", $.property_set_parameter, ")"),
 
   property_set_parameter: ($) => $.__class_named_parameter_body,

--- a/grammar/statements/class.js
+++ b/grammar/statements/class.js
@@ -189,7 +189,8 @@ export default ({ kw }) => ({
     choice(seq("(", ")"), $.property_set_parameter_list),
   property_set_parameter_list: ($) => seq("(", $.property_set_parameter, ")"),
 
-  property_set_parameter: ($) => $.__class_named_parameter_body,
+  property_set_parameter: ($) =>
+    seq(optional(field("direction", $._parameter_direction)), $.__class_named_parameter_body),
   __class_named_parameter_body: ($) =>
     seq(
       field("name", $.identifier),

--- a/grammar/statements/create-widget.js
+++ b/grammar/statements/create-widget.js
@@ -27,21 +27,7 @@ export default ({ kw }) => ({
       ),
       optional($._handle_in_widget_pool),
       optional($.assign_phrase),
-      optional($.__create_widget_triggers),
+      optional($.trigger_phrase),
     ),
 
-  __create_widget_triggers: ($) =>
-    seq(
-      kw("TRIGGERS"),
-      alias($._colon, ":"),
-      repeat1(
-        seq(
-          kw("ON"),
-          field("event", choice(kw("CHOOSE"), kw("ENTRY"), kw("LEAVE"), $.identifier)),
-          $.do_statement,
-        ),
-      ),
-      kw("END"),
-      kw("TRIGGERS"),
-    ),
 });

--- a/grammar/statements/create.js
+++ b/grammar/statements/create.js
@@ -33,7 +33,9 @@ export default ({ kw }) => ({
       kw("FOR"),
       kw("TABLE"),
       field("table", $.__create_buffer_target),
-      optional(seq(kw("BUFFER-NAME"), field("name", $.identifier))),
+      optional(
+        seq(kw("BUFFER-NAME"), field("name", choice($._identifier_or_qualified_name, $.string_literal))),
+      ),
       optional($._in_widget_pool),
     ),
   __create_buffer_target: ($) => choice($._identifier_or_access_or_call, $.string_literal),

--- a/grammar/statements/frame.js
+++ b/grammar/statements/frame.js
@@ -45,12 +45,8 @@ export default ({ kw }) => ({
       prec.right(alias(kw("SKIP"), $.skip)),
       seq(
         field("field", $._identifier_or_array_access),
-        optional(
-          choice(
-            alias($.at_phrase, $.format_phrase),
-            alias($.__frame_field_format_phrase, $.format_phrase),
-          ),
-        ),
+        optional(alias($.at_phrase, $.format_phrase)),
+        optional(alias($.__frame_field_format_phrase, $.format_phrase)),
       ),
       seq($.preprocessor_name, optional($.__frame_display_value_tail)),
       seq(field("value", $.string_literal), optional($.__frame_display_value_tail)),

--- a/grammar/statements/frame.js
+++ b/grammar/statements/frame.js
@@ -72,6 +72,7 @@ export default ({ kw }) => ({
       repeat1(
         choice(
           $._format_field_option,
+          $._tooltip_phrase,
           alias(kw("AUTO-RETURN"), $.auto_return),
           alias(kw("BLANK"), $.blank),
           alias(kw("DEBLANK"), $.deblank),

--- a/grammar/statements/function.js
+++ b/grammar/statements/function.js
@@ -76,9 +76,23 @@ export default ({ kw }) => ({
   __function_parameter: ($) =>
     seq(
       optional(field("direction", $._parameter_direction)),
-      field("name", $.identifier),
-      $.__function_variable_type_phrase,
-      optional(alias(kw("NO-UNDO"), $.no_undo)),
+      choice(
+        seq(
+          field("name", $.identifier),
+          $.__function_variable_type_phrase,
+          optional(alias(kw("NO-UNDO"), $.no_undo)),
+        ),
+        seq(
+          kw("BUFFER"),
+          field("buffer", $.identifier),
+          kw("FOR"),
+          field("table", $._identifier_or_qualified_name),
+        ),
+        seq(kw("TABLE"), field("table", $.identifier)),
+        seq(kw("TABLE-HANDLE"), field("table_handle", $.identifier)),
+        seq(kw("DATASET"), kw("FOR"), field("dataset", $._identifier_or_qualified_name)),
+        seq(kw("DATASET-HANDLE"), field("dataset_handle", $.identifier)),
+      ),
     ),
 
   __function_variable_type_phrase: ($) => seq($._as_like, optional($._extent_phrase)),

--- a/grammar/statements/hide.js
+++ b/grammar/statements/hide.js
@@ -10,5 +10,5 @@ export default ({ kw }) => ({
       $.in_window_phrase,
     ),
   __hide_target: ($) =>
-    choice(alias(kw("MESSAGE"), $.message), alias(kw("ALL"), $.all), $.widget_phrase),
+    choice(alias(kw("MESSAGE"), $.message), alias(kw("ALL"), $.all), repeat1($.widget_phrase)),
 });

--- a/grammar/statements/os-delete.js
+++ b/grammar/statements/os-delete.js
@@ -9,5 +9,5 @@ export default ({ kw }) => ({
     ),
 
   __os_delete_target: ($) =>
-    choice($._os_filename, seq(kw("VALUE"), "(", field("value", $._os_filename), ")")),
+    choice($._os_filename, seq(kw("VALUE"), "(", field("value", $._expression), ")")),
 });

--- a/grammar/statements/procedure.js
+++ b/grammar/statements/procedure.js
@@ -6,6 +6,7 @@ export default ({ kw }) => ({
       kw("PROCEDURE", { offset: 4 }),
       optional($.__procedure_modifier),
       field("name", $._identifier_or_qualified_name),
+      optional($.__procedure_modifier),
       repeat(
         choice(
           alias(kw("CDECL"), $.cdecl),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -436,7 +436,6 @@
   "END"
   "END-KEY"
   "ENDKEY"
-  "ENTRY"
   "ENUM"
   "EQ"
   "ERROR"

--- a/test/corpus/phrases/combo-box.txt
+++ b/test/corpus/phrases/combo-box.txt
@@ -18,3 +18,22 @@ DEFINE VARIABLE v AS CHARACTER VIEW-AS COMBO-BOX LIST-ITEMS "a", "b" SIZE 10 BY 
           width: (number_literal)
           height: (number_literal))
         (unique_match)))))
+
+================================================================================
+COMBO-BOX - LIST-ITEMS after another option
+================================================================================
+
+DEFINE VARIABLE v AS CHARACTER VIEW-AS COMBO-BOX INNER-LINES 5 LIST-ITEMS "a","b" NO-UNDO.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (variable_definition
+    name: (identifier)
+    type: (identifier)
+    (view_as_phrase
+      (combo_box_phrase
+        inner_lines: (number_literal)
+        items: (string_literal)
+        items: (string_literal)))
+    (no_undo)))

--- a/test/corpus/phrases/format.txt
+++ b/test/corpus/phrases/format.txt
@@ -62,3 +62,20 @@ DISPLAY x AT ROW 3.
       field: (identifier))
     (format_phrase
       row: (number_literal))))
+
+================================================================================
+FORMAT - VIEW-AS TOGGLE-BOX with SIZE
+================================================================================
+
+DISPLAY x VIEW-AS TOGGLE-BOX SIZE 10 BY 1.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (display_statement
+    (field
+      field: (identifier))
+    (format_phrase
+      (size_phrase
+        width: (number_literal)
+        height: (number_literal)))))

--- a/test/corpus/phrases/format.txt
+++ b/test/corpus/phrases/format.txt
@@ -79,3 +79,20 @@ DISPLAY x VIEW-AS TOGGLE-BOX SIZE 10 BY 1.
       (size_phrase
         width: (number_literal)
         height: (number_literal)))))
+
+================================================================================
+FORMAT - VIEW-AS FILL-IN
+================================================================================
+
+DISPLAY x VIEW-AS FILL-IN SIZE 10 BY 1.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (display_statement
+    (field
+      field: (identifier))
+    (format_phrase
+      (size_phrase
+        width: (number_literal)
+        height: (number_literal)))))

--- a/test/corpus/phrases/trigger.txt
+++ b/test/corpus/phrases/trigger.txt
@@ -65,3 +65,19 @@ DEFINE VARIABLE d AS CHARACTER TRIGGERS: ON GO PERSISTENT RUN "handler" IN (h) (
         (identifier))
       parameters: (number_literal)
       parameters: (identifier))))
+
+================================================================================
+TRIGGERS - persistent procedure with terminator
+================================================================================
+
+DEFINE VARIABLE a AS CHARACTER TRIGGERS: ON GO PERSISTENT RUN "h". END TRIGGERS.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (variable_definition
+    name: (identifier)
+    type: (identifier)
+    (trigger_phrase
+      event: (identifier)
+      procedure: (string_literal))))

--- a/test/corpus/statements/buffer-copy.txt
+++ b/test/corpus/statements/buffer-copy.txt
@@ -102,3 +102,23 @@ BUFFER-COPY bSrc TO bTgt ASSIGN Cust.Name = "X" Cust.Balance -= 10.
           left: (identifier)
           right: (identifier))
         right: (number_literal)))))
+
+================================================================================
+BUFFER-COPY - ASSIGN pair with WHEN
+================================================================================
+
+BUFFER-COPY src TO tgt ASSIGN fld = 1 WHEN x > 0.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (buffer_copy_statement
+    source: (identifier)
+    target: (identifier)
+    (assign_phrase
+      (assign_pair
+        left: (identifier)
+        right: (number_literal)
+        when: (binary_expression
+          (identifier)
+          (number_literal))))))

--- a/test/corpus/statements/case.txt
+++ b/test/corpus/statements/case.txt
@@ -119,3 +119,27 @@ END.
       condition: (string_literal)
       (run_statement
         procedure: (identifier)))))
+
+================================================================================
+CASE - include reference in the body
+================================================================================
+
+CASE x:
+  {inc/foo.i}
+  WHEN 1 THEN y = 1.
+END CASE.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (case_statement
+    (identifier)
+    (include_file_reference
+      file: (include_file_path
+        (identifier)))
+    (case_when_phrase
+      condition: (number_literal)
+      (assignment_statement
+        left: (identifier)
+        operator: (assignment_operator)
+        right: (number_literal)))))

--- a/test/corpus/statements/catch.txt
+++ b/test/corpus/statements/catch.txt
@@ -114,3 +114,23 @@ END.
           right: (identifier))
         (body
           (undo_statement))))))
+
+================================================================================
+CATCH - unqualified error type
+================================================================================
+
+DO ON ERROR UNDO, THROW:
+  CATCH e AS MyError:
+  END CATCH.
+END.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (do_statement
+    (on_error_phrase)
+    (body
+      (catch_statement
+        name: (identifier)
+        type: (identifier)
+        (body)))))

--- a/test/corpus/statements/class.txt
+++ b/test/corpus/statements/class.txt
@@ -509,3 +509,22 @@ END CLASS.
           type: (identifier)))
       (return_statement
         value: (string_literal)))))
+
+================================================================================
+DESTRUCTOR - closed with END METHOD
+================================================================================
+
+CLASS Foo:
+  DESTRUCTOR Foo():
+  END METHOD.
+END CLASS.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (class_definition
+    name: (identifier)
+    (destructor_definition
+      name: (identifier)
+      (parameters)
+      (body))))

--- a/test/corpus/statements/class.txt
+++ b/test/corpus/statements/class.txt
@@ -528,3 +528,20 @@ END CLASS.
       name: (identifier)
       (parameters)
       (body))))
+
+================================================================================
+CLASS - routine-level error scope in the body
+================================================================================
+
+CLASS Foo:
+  ROUTINE-LEVEL ON ERROR UNDO, THROW.
+END CLASS.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (class_definition
+    name: (identifier)
+    (error_scope_statement
+      (error_scope_type)
+      (on_error_phrase))))

--- a/test/corpus/statements/class.txt
+++ b/test/corpus/statements/class.txt
@@ -460,3 +460,24 @@ END CLASS.
       (no_undo)
       (return_statement
         value: (string_literal)))))
+
+================================================================================
+PROPERTY - accessor with its own access modifier
+================================================================================
+
+CLASS Foo:
+  DEFINE PUBLIC PROPERTY p AS CHARACTER NO-UNDO
+    PROTECTED SET.
+END CLASS.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (class_definition
+    name: (identifier)
+    (property_definition
+      (access_modifier)
+      name: (identifier)
+      type: (identifier)
+      (no_undo)
+      (access_modifier))))

--- a/test/corpus/statements/class.txt
+++ b/test/corpus/statements/class.txt
@@ -436,3 +436,27 @@ END CLASS.
 (source_code
   (class_definition
     name: (identifier)))
+
+================================================================================
+PROPERTY - accessor with empty parentheses
+================================================================================
+
+CLASS Foo:
+  DEFINE PUBLIC PROPERTY p AS CHARACTER NO-UNDO
+    GET():
+      RETURN "".
+    END GET.
+END CLASS.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (class_definition
+    name: (identifier)
+    (property_definition
+      (access_modifier)
+      name: (identifier)
+      type: (identifier)
+      (no_undo)
+      (return_statement
+        value: (string_literal)))))

--- a/test/corpus/statements/class.txt
+++ b/test/corpus/statements/class.txt
@@ -481,3 +481,31 @@ END CLASS.
       type: (identifier)
       (no_undo)
       (access_modifier))))
+
+================================================================================
+PROPERTY - accessor parameter with a direction
+================================================================================
+
+CLASS Foo:
+  DEFINE PUBLIC PROPERTY p AS CHARACTER NO-UNDO
+    GET(INPUT i AS INTEGER):
+      RETURN "".
+    END GET.
+END CLASS.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (class_definition
+    name: (identifier)
+    (property_definition
+      (access_modifier)
+      name: (identifier)
+      type: (identifier)
+      (no_undo)
+      (property_set_parameter_list
+        (property_set_parameter
+          name: (identifier)
+          type: (identifier)))
+      (return_statement
+        value: (string_literal)))))

--- a/test/corpus/statements/create-widget.txt
+++ b/test/corpus/statements/create-widget.txt
@@ -34,12 +34,13 @@ END TRIGGERS.
         right: (boolean_literal))))
   (create_widget_statement
     handle: (identifier)
-    (do_statement
-      (body
+    (trigger_phrase
+      event: (identifier)
+      (trigger_body
         (message_statement
-          (string_literal))))
-    (do_statement
-      (body
+          (string_literal)))
+      event: (identifier)
+      (trigger_body
         (message_statement
           (string_literal))))))
 
@@ -89,3 +90,22 @@ CREATE BUTTON hBtn[1].
     handle: (array_access
       array: (identifier)
       index: (number_literal))))
+
+================================================================================
+CREATE WIDGET - event list and END without TRIGGERS
+================================================================================
+
+CREATE BUTTON hBtn TRIGGERS:
+  ON CHOOSE, ENTRY DO:
+  END.
+END.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (create_widget_statement
+    handle: (identifier)
+    (trigger_phrase
+      event: (identifier)
+      event: (identifier)
+      (trigger_body))))

--- a/test/corpus/statements/create-widget.txt
+++ b/test/corpus/statements/create-widget.txt
@@ -75,3 +75,17 @@ CREATE BROWSE hBr IN WIDGET-POOL wp ASSIGN TITLE = "t".
       (assign_pair
         left: (identifier)
         right: (string_literal)))))
+
+================================================================================
+CREATE WIDGET - array handle
+================================================================================
+
+CREATE BUTTON hBtn[1].
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (create_widget_statement
+    handle: (array_access
+      array: (identifier)
+      index: (number_literal))))

--- a/test/corpus/statements/create.txt
+++ b/test/corpus/statements/create.txt
@@ -298,3 +298,17 @@ CREATE BUFFER hBuf FOR TABLE "cust" BUFFER-NAME "b1".
     handle: (identifier)
     table: (string_literal)
     name: (string_literal)))
+
+================================================================================
+CREATE BUFFER - widget pool named by a string
+================================================================================
+
+CREATE BUFFER h FOR TABLE "t" IN WIDGET-POOL "myPool".
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (create_statement
+    handle: (identifier)
+    table: (string_literal)
+    pool: (string_literal)))

--- a/test/corpus/statements/create.txt
+++ b/test/corpus/statements/create.txt
@@ -270,3 +270,31 @@ CREATE BUFFER hUS FOR TABLE "UserSession".
   (create_statement
     handle: (identifier)
     table: (string_literal)))
+
+================================================================================
+CREATE - array handle
+================================================================================
+
+CREATE QUERY hQry[2].
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (create_statement
+    handle: (array_access
+      array: (identifier)
+      index: (number_literal))))
+
+================================================================================
+CREATE BUFFER - BUFFER-NAME as a string
+================================================================================
+
+CREATE BUFFER hBuf FOR TABLE "cust" BUFFER-NAME "b1".
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (create_statement
+    handle: (identifier)
+    table: (string_literal)
+    name: (string_literal)))

--- a/test/corpus/statements/dataset.txt
+++ b/test/corpus/statements/dataset.txt
@@ -237,3 +237,21 @@ DEFINE DATASET dsPidFields FOR ttParent, ttChild PARENT-ID-RELATION FOR ttParent
       parent_id_field: (identifier)
       before_field: (identifier)
       after_field: (identifier))))
+
+================================================================================
+DATASET - reference with arguments
+================================================================================
+
+x = DATASET dsFoo(1).
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (assignment_statement
+    left: (identifier)
+    operator: (assignment_operator)
+    right: (dataset_reference
+      dataset: (identifier)
+      (arguments
+        (argument
+          name: (number_literal))))))

--- a/test/corpus/statements/frame.txt
+++ b/test/corpus/statements/frame.txt
@@ -1159,3 +1159,18 @@ DEFINE FRAME fr fld1 AT 5 FORMAT "x(10)".
       position: (number_literal))
     (format_phrase
       format: (string_literal))))
+
+================================================================================
+FRAME - field with TOOLTIP
+================================================================================
+
+DEFINE FRAME fr fld1 TOOLTIP "aide".
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (frame_definition
+    name: (identifier)
+    field: (identifier)
+    (format_phrase
+      tooltip: (string_literal))))

--- a/test/corpus/statements/frame.txt
+++ b/test/corpus/statements/frame.txt
@@ -1142,3 +1142,20 @@ WAIT-FOR WINDOW-CLOSE OF FRAME cust-fr.
       events: (identifier)
       widgets: (widget_phrase
         frame: (identifier)))))
+
+================================================================================
+FRAME - field with both AT and FORMAT
+================================================================================
+
+DEFINE FRAME fr fld1 AT 5 FORMAT "x(10)".
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (frame_definition
+    name: (identifier)
+    field: (identifier)
+    (format_phrase
+      position: (number_literal))
+    (format_phrase
+      format: (string_literal))))

--- a/test/corpus/statements/function.txt
+++ b/test/corpus/statements/function.txt
@@ -772,3 +772,53 @@ END.
               name: (binary_expression
                 (identifier)
                 (number_literal)))))))))
+
+================================================================================
+FUNCTION - table, dataset and buffer parameters
+================================================================================
+
+FUNCTION f RETURNS CHARACTER (BUFFER pBuf FOR myTable) FORWARD.
+FUNCTION g RETURNS CHARACTER (TABLE tt) FORWARD.
+FUNCTION h RETURNS CHARACTER (TABLE-HANDLE ht) FORWARD.
+FUNCTION i RETURNS CHARACTER (DATASET FOR ds) FORWARD.
+FUNCTION j RETURNS CHARACTER (DATASET-HANDLE hd) FORWARD.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (function_forward_definition
+    name: (identifier)
+    type: (identifier)
+    (parameters
+      (parameter
+        buffer: (identifier)
+        table: (identifier)))
+    (forward))
+  (function_forward_definition
+    name: (identifier)
+    type: (identifier)
+    (parameters
+      (parameter
+        table: (identifier)))
+    (forward))
+  (function_forward_definition
+    name: (identifier)
+    type: (identifier)
+    (parameters
+      (parameter
+        table_handle: (identifier)))
+    (forward))
+  (function_forward_definition
+    name: (identifier)
+    type: (identifier)
+    (parameters
+      (parameter
+        dataset: (identifier)))
+    (forward))
+  (function_forward_definition
+    name: (identifier)
+    type: (identifier)
+    (parameters
+      (parameter
+        dataset_handle: (identifier)))
+    (forward)))

--- a/test/corpus/statements/hide.txt
+++ b/test/corpus/statements/hide.txt
@@ -128,3 +128,18 @@ HIDE ALL NO-PAUSE IN WINDOW w1.
     (no_pause)
     (in_window_phrase
       window: (identifier))))
+
+================================================================================
+HIDE - several widgets
+================================================================================
+
+HIDE FRAME f1 FRAME f2.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (hide_statement
+    (widget_phrase
+      frame: (identifier))
+    (widget_phrase
+      frame: (identifier))))

--- a/test/corpus/statements/message.txt
+++ b/test/corpus/statements/message.txt
@@ -504,3 +504,17 @@ MESSAGE "Select" VIEW-AS ALERT-BOX SET flag VIEW-AS ALERT-BOX QUESTION BUTTONS Y
         (view_as_phrase
           (alert_type)
           title: (string_literal))))))
+
+================================================================================
+MESSAGE - alert box title from a variable
+================================================================================
+
+MESSAGE "x" VIEW-AS ALERT-BOX TITLE cTitle.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (message_statement
+    (string_literal)
+    (view_as_phrase
+      title: (identifier))))

--- a/test/corpus/statements/os-delete.txt
+++ b/test/corpus/statements/os-delete.txt
@@ -81,3 +81,17 @@ OS-DELETE VALUE(cPath) "tmp" RECURSIVE.
     value: (identifier)
     (string_literal)
     (recursive)))
+
+================================================================================
+OS-DELETE - VALUE with an expression
+================================================================================
+
+OS-DELETE VALUE(cPath + "x").
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (os_delete_statement
+    value: (binary_expression
+      (identifier)
+      (string_literal))))

--- a/test/corpus/statements/procedure.txt
+++ b/test/corpus/statements/procedure.txt
@@ -715,3 +715,18 @@ END PROCEDURE.
       right: (identifier)
       right: (identifier))
     (body)))
+
+================================================================================
+PROCEDURE - modifier after the name
+================================================================================
+
+PROCEDURE p PRIVATE:
+END PROCEDURE.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (procedure_definition
+    name: (identifier)
+    (access_modifier)
+    (body)))

--- a/test/corpus/statements/run.txt
+++ b/test/corpus/statements/run.txt
@@ -463,3 +463,30 @@ RUN x (INPUT oid_{&QXO-TABLE}).
     (arguments
       (argument
         name: (macro_concatenated_name)))))
+
+================================================================================
+RUN - BY-VALUE, APPEND and BIND parameter modifiers
+================================================================================
+
+RUN p (INPUT x BY-VALUE).
+RUN p (INPUT x APPEND).
+RUN p (INPUT x BIND).
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (run_statement
+    procedure: (identifier)
+    (arguments
+      (argument
+        name: (identifier))))
+  (run_statement
+    procedure: (identifier)
+    (arguments
+      (argument
+        name: (identifier))))
+  (run_statement
+    procedure: (identifier)
+    (arguments
+      (argument
+        name: (identifier)))))


### PR DESCRIPTION
Second batch from #118: 25 commits, 35 fixes, one semantic change per commit with its corpus test.

Three of them are **silent misparses** — no `ERROR` node today, but the tree describes fields that are not in the source:

```abl
DEFINE FRAME fr fld1 TOOLTIP "aide".
```
before: `field: fld1`, **`field: TOOLTIP`**, `value: "aide"` — the keyword becomes a second field name.

```abl
DEFINE FRAME fr fld1 AT 5 FORMAT "x(10)".
```
before: `format_phrase(position)`, then **`field: FORMAT`**, `value: "x(10)"`.

```abl
DISPLAY x VIEW-AS TOGGLE-BOX SIZE 10 BY 1.
```
before: an empty `(format_phrase)` then four bogus display fields — `SIZE`, `10`, `BY`, `1`.

### What is in

| Area | Fixes |
|---|---|
| Display phrases | `AT`+`FORMAT` together, `TOOLTIP` as a frame field option, `SIZE`/`TOOLTIP` after `VIEW-AS`, `VIEW-AS FILL-IN`, `COMBO-BOX` list items after other options |
| Routine parameters | `BUFFER FOR`, `TABLE`, `TABLE-HANDLE`, `DATASET FOR`, `DATASET-HANDLE` in FUNCTION signatures; `BY-VALUE`, `APPEND`, `BIND` modifiers |
| CREATE | array element as handle, `BUFFER-NAME` as a string, terminator after `PERSISTENT RUN`, and CREATE WIDGET switched onto `trigger_phrase` |
| Classes | accessor parameter lists, accessor access modifiers, parameter direction, `END METHOD` on destructors, error scope in a class body |
| Statements | `BUFFER-COPY … WHEN`, multi-widget `HIDE`, unqualified `CATCH` type, widget pool named by a string, alert box title from a variable, include inside `CASE`, `OS-DELETE VALUE(expr)`, `PROCEDURE` modifier after the name, `DATASET` arguments |

### Design notes

Most fixes land on rules you already share rather than on the file where the symptom appeared: `_parameter_direction` (7 call sites), `_tooltip_phrase`, `_handle_in_widget_pool`, `_in_widget_pool`, `_alert_box_title`, `property_set_parameter`. Our fork had duplicated several of these locally; re-deriving them here made them narrower and wider at once.

The CREATE WIDGET commit **deletes** its private trigger block in favour of `trigger_phrase`, which already models comma-separated events, `END` without `TRIGGERS`, and `PERSISTENT RUN`. That commit shrinks the parser. It also updates one existing corpus tree — the rule changed, so the tree changed — and removes `"ENTRY"` from `highlights.scm`, since that rule was its only unaliased producer and the node type no longer exists.

Two conflicts were resolved by associativity plus one entry in the `binary_expression` precedence list next to `size_phrase`. **No `conflicts` entry was added.**

### Numbers

| | upstream | this branch | delta |
|---|---|---|---|
| `ACTION_COUNT` | 37 735 | 39 197 | +1 462 (+3.9 %) |
| `STATE_COUNT` | 29 576 | 31 388 | +1 812 |
| `LARGE_STATE_COUNT` | 13 627 | 14 808 | +1 181 |
| `src/parser.c` | 105.71 MiB | 112.63 MiB | +6.92 MiB |

Per area, since the cost is very uneven: display phrases **+1 049**, routine parameters +129, CREATE **−32**, classes and statements +316 together. If you want to trim, display phrases is the only place worth looking — the `VIEW-AS` tail and `TOOLTIP` as a frame option are what cost.

Corpus: **1092 passing, 0 failing**. No generated files included.

### Deliberately left out

These were measured as missing too, but each needs a decision we did not want to bury in a 25-commit PR:

- `CREATE BUTTON h NO-ERROR.` — the modifier is ambiguous against the `ASSIGN` phrase in `CREATE … ASSIGN x = 1 NO-ERROR.`, and every resolution we found changes `__assign_body` globally.
- `arr[i]:prop` — `object_access` has been restructured into three prefixes here; the fix needs re-deriving against that.
- `$` in identifiers — you already accept `%`, so this is a one-character lexical widening, but a global one.
- `RUN some/path/proc`, `RUN proc{&MACRO}`, `RUN p IN hArr[1]`, `preprocessor_name` as a widget handle.

Happy to send any of them as follow-ups, together or separately, whichever you prefer.
