### PR TITLE
grammar: RUN targets, object access receivers and dollar identifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -438,7 +438,7 @@ export default grammar({
           $._object_access_tail,
         ),
       _object_access_expression_left: ($) =>
-        choice($.function_call, $.parenthesized_expression, $.new_expression),
+        choice($.function_call, $.parenthesized_expression, $.new_expression, $.array_access),
 
       scoped_name: ($) => seq(field("left", $.identifier), $.__scoped_name_tail),
       __scoped_name_tail: ($) =>

--- a/grammar.js
+++ b/grammar.js
@@ -413,7 +413,7 @@ export default grammar({
       _object_access_plain_prefix: ($) =>
         field("left", choice($._object_access_plain_left, $._object_access_expression_left)),
       _object_access_plain_left: ($) =>
-        choice($._identifier_or_qualified_name, $.system_handle_identifier),
+        choice($._identifier_or_qualified_name, $.system_handle_identifier, $.preprocessor_name),
       _object_access_widget_prefix: ($) =>
         seq(
           field("widget", alias($._widgets, $.identifier)),

--- a/grammar.js
+++ b/grammar.js
@@ -533,7 +533,7 @@ export default grammar({
 
       // Identifiers
       // BE CAREFUL MODIFYING HERE, IDENTIFIER ORDER FOR SOME REASON MATTERS!
-      identifier: ($) => token(/[_\p{L}][\p{L}\p{N}_\-&#%]*/i),
+      identifier: ($) => token(/[_\p{L}][\p{L}\p{N}_\-&#%$]*/i),
       system_handle_identifier: ($) =>
         alias(
           token(prec(1, new RegExp(`(${SYSTEM_HANDLE_WORDS.map(escape_regex).join("|")})`, "i"))),

--- a/grammar/precedences/browse.js
+++ b/grammar/precedences/browse.js
@@ -3,4 +3,9 @@ export default ($) => [
   // Purpose: prefer function call when ENABLE list item is followed by '('.
   // Example: DEFINE BROWSE b QUERY q DISPLAY rec EXCEPT f ENABLE myFunc().
   [$.function_call, $.__browse_enable_field],
+  // Purpose: read a subscripted ENABLE item as a browse field rather than as an
+  // array access expression opening the item.
+  // Example: DEFINE BROWSE b QUERY q DISPLAY rec ENABLE fld[1].
+  // Reference: DEFINE BROWSE statement; array reference.
+  [$.__browse_enable_field, $.__array_access_prefix],
 ];

--- a/grammar/statements/run.js
+++ b/grammar/statements/run.js
@@ -71,6 +71,7 @@ export default ({ kw }) => ({
       alias(kw("THIS-PROCEDURE"), $.this_procedure),
       alias(kw("THIS-OBJECT"), $.this_object),
       $.object_access,
+      $.array_access,
       $._identifier_or_qualified_name,
     ),
 });

--- a/grammar/statements/run.js
+++ b/grammar/statements/run.js
@@ -35,6 +35,7 @@ export default ({ kw }) => ({
       alias($._value_expression, $.value_expression),
       alias($.__run_library_member, $.library_member),
       $.procedure_name,
+      $.macro_concatenated_name,
       $.identifier,
       $.qualified_name,
     ),

--- a/test/corpus/statements/expression.txt
+++ b/test/corpus/statements/expression.txt
@@ -96,3 +96,20 @@ IF ENTERED wfeven THEN RETURN.
     (entered_expression
       field: (identifier))
     then: (return_statement)))
+
+================================================================================
+OBJECT ACCESS - preprocessor name as the receiver
+================================================================================
+
+{&WIN}:TITLE = "x".
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (assignment_statement
+    left: (object_access
+      left: (preprocessor_name
+        (identifier))
+      right: (identifier))
+    operator: (assignment_operator)
+    right: (string_literal)))

--- a/test/corpus/statements/expression.txt
+++ b/test/corpus/statements/expression.txt
@@ -113,3 +113,21 @@ OBJECT ACCESS - preprocessor name as the receiver
       right: (identifier))
     operator: (assignment_operator)
     right: (string_literal)))
+
+================================================================================
+OBJECT ACCESS - array element as the receiver
+================================================================================
+
+x = arr[1]:HANDLE.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (assignment_statement
+    left: (identifier)
+    operator: (assignment_operator)
+    right: (object_access
+      left: (array_access
+        array: (identifier)
+        index: (number_literal))
+      right: (identifier))))

--- a/test/corpus/statements/run.txt
+++ b/test/corpus/statements/run.txt
@@ -490,3 +490,15 @@ RUN p (INPUT x BIND).
     (arguments
       (argument
         name: (identifier)))))
+
+================================================================================
+RUN - macro-concatenated procedure name
+================================================================================
+
+RUN proc{&SUF}.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (run_statement
+    procedure: (macro_concatenated_name)))

--- a/test/corpus/statements/run.txt
+++ b/test/corpus/statements/run.txt
@@ -502,3 +502,19 @@ RUN proc{&SUF}.
 (source_code
   (run_statement
     procedure: (macro_concatenated_name)))
+
+================================================================================
+RUN - IN with an array element handle
+================================================================================
+
+RUN p IN hArr[1].
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (run_statement
+    procedure: (identifier)
+    (in_phrase
+      context: (array_access
+        array: (identifier)
+        index: (number_literal)))))

--- a/test/corpus/statements/variable.txt
+++ b/test/corpus/statements/variable.txt
@@ -952,3 +952,17 @@ DEFINE VARIABLE y EXTENT 3 LIKE ttRecord.fieldArr[2] NO-UNDO.
         right: (identifier))
       index: (number_literal))
     (no_undo)))
+
+================================================================================
+IDENTIFIER - dollar sign in legacy names
+================================================================================
+
+DEFINE VARIABLE p$typ_rem AS CHARACTER NO-UNDO.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (variable_definition
+    name: (identifier)
+    type: (identifier)
+    (no_undo)))


### PR DESCRIPTION
Third and last batch from #118 — the fixes we deliberately held back from #120 because they touch expressions, the lexer, or a central rule. Parser deltas are now in every commit description, as asked in #119.

One item dropped from our list: `RUN some/path/MyProc` already parses on current master, so nothing to send there.

### What is in

| Fix | ACTION_COUNT |
|---|---|
| macro-concatenated `RUN` target — `RUN proc{&SUF}.` | +2 |
| array element as `RUN … IN` context — `RUN p IN hArr[1].` | 0 |
| preprocessor name as object access receiver — `{&WIN}:TITLE = "x".` | +8 |
| array element as object access receiver — `x = arr[1]:HANDLE.` | 0 |
| `$` in identifiers — `p$typ_rem` | 0 |
| **total** | **+10** |

`ACTION_COUNT` 39 179 → 39 189, `STATE_COUNT` 31 399 → 31 416, `src/parser.c` +106 132 bytes. Corpus: **1101 passing, 0 failing**.

The `$` commit adds one character to a class that already contained `%`; it costs nothing and the generated parser comes out slightly smaller.

Allowing an array element as an object access receiver made a subscripted browse `ENABLE` item ambiguous. Resolved with a precedence entry preferring the browse field, per the convention of trying precedences first. **No `conflicts` entry was added** — our fork had used one here, and re-deriving the fix on your tree turned out not to need it.

---

## One finding, not fixed here

While writing a control case for the precedence entry above, we found what looks like a fourth silent misparse — it predates this branch, we verified it on master without our changes:

```abl
DEFINE BROWSE b QUERY q DISPLAY rec ENABLE fld[1] WITH 10 DOWN.
```

```
(browse_definition
  name: (identifier)
  query: (identifier)
  (column column: (identifier))
  field: (identifier)
  field: (number_literal)     <-- the subscript becomes a second field
  down: (number_literal))
```

`__browse_enable_field` does accept `optional(seq("[", optional($._array_subscript), "]"))`, but the subscript is unlabelled and `1` surfaces as another `field`. No `ERROR` node, so nothing signals it. There is no corpus case covering `ENABLE` with a subscript, which is presumably why it went unnoticed.

We did not touch it — it is outside this branch's scope and the right shape depends on what you want the tree to look like. Happy to send a fix if you tell us whether the index should be `field("index", …)` on the enable field, or something else.

## One question

`CREATE BUTTON h NO-ERROR.` still does not parse, and we could not fix it without touching a rule that is yours to arbitrate. Adding the modifier to `create_widget_statement` produces:

```
'create_statement_token1' … '__assign_statement_prefix_token1'{"ASSIGN"}  __assign_body_repeat1  •  {"no_error"}

  1:  Specify a left or right associativity in `__assign_body`
  2:  Add a conflict for these rules: `__assign_body`
```

In `CREATE WINDOW h ASSIGN x = 1 NO-ERROR.` the keyword can close the ASSIGN phrase or the CREATE statement. Every resolution we found changes `__assign_body`, i.e. the ASSIGN statement everywhere, which seemed disproportionate for one optional modifier — and not our call to make. Would you rather we sent it with an associativity on `__assign_body`, or is there a shape you would prefer?
