### PR TITLE
grammar: browse subscripts, CREATE NO-ERROR, and the string case-marker

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -301,11 +301,7 @@ export default grammar({
       number_literal: ($) => token(/([0-9]+(\.[0-9]+)?|\.[0-9]+)/),
       _signed_number_literal: ($) => token(/[+-]([0-9]+(\.[0-9]+)?|\.[0-9]+)/),
       date_literal: ($) => token(/[0-9]{1,2}[./][0-9]{1,2}[./][0-9]{2,4}/),
-      string_literal: ($) =>
-        seq(
-          $._escaped_string,
-          optional(token.immediate(/:(?:[RLCT](?:U)?(?:[0-9]+)?|U(?:[0-9]+)?|[0-9]+)/i)),
-        ),
+      string_literal: ($) => $._escaped_string,
       null_literal: ($) => token("?"),
       boolean_literal: ($) => choice(kw("TRUE"), kw("FALSE"), kw("YES"), kw("NO")),
       procedure_name: ($) => /[A-Za-z0-9_\\/.-]+\.pl?/i,

--- a/grammar/phrases/assign.js
+++ b/grammar/phrases/assign.js
@@ -1,11 +1,9 @@
 export default ({ kw }) => ({
   assign_phrase: ($) => seq(kw("ASSIGN"), $.__assign_body),
 
-  __assign_body: ($) =>
-    seq(
-      repeat1(alias($.__assign_pair, $.assign_pair)),
-      optional(alias(kw("NO-ERROR"), $.no_error)),
-    ),
+  __assign_body: ($) => seq($._assign_pairs, optional(alias(kw("NO-ERROR"), $.no_error))),
+
+  _assign_pairs: ($) => repeat1(alias($.__assign_pair, $.assign_pair)),
 
   __assign_pair: ($) =>
     seq(

--- a/grammar/precedences/browse.js
+++ b/grammar/precedences/browse.js
@@ -3,9 +3,4 @@ export default ($) => [
   // Purpose: prefer function call when ENABLE list item is followed by '('.
   // Example: DEFINE BROWSE b QUERY q DISPLAY rec EXCEPT f ENABLE myFunc().
   [$.function_call, $.__browse_enable_field],
-  // Purpose: read a subscripted ENABLE item as a browse field rather than as an
-  // array access expression opening the item.
-  // Example: DEFINE BROWSE b QUERY q DISPLAY rec ENABLE fld[1].
-  // Reference: DEFINE BROWSE statement; array reference.
-  [$.__browse_enable_field, $.__array_access_prefix],
 ];

--- a/grammar/statements/browse.js
+++ b/grammar/statements/browse.js
@@ -163,8 +163,7 @@ export default ({ kw }) => ({
 
   __browse_enable_field: ($) =>
     seq(
-      field("field", choice($._identifier_or_qualified_name, $.object_access)),
-      optional(seq("[", optional($._array_subscript), "]")),
+      field("field", choice($._identifier_or_qualified_name, $.object_access, $.array_access)),
       repeat($.format_phrase),
     ),
 });

--- a/grammar/statements/create-widget.js
+++ b/grammar/statements/create-widget.js
@@ -26,8 +26,11 @@ export default ({ kw }) => ({
         seq(kw("VALUE"), "(", field("widget_type", $._expression), ")"),
       ),
       optional($._handle_in_widget_pool),
-      optional($.assign_phrase),
+      optional(alias($.__create_widget_assign_phrase, $.assign_phrase)),
       optional($.trigger_phrase),
+      optional(alias(kw("NO-ERROR"), $.no_error)),
     ),
+
+  __create_widget_assign_phrase: ($) => seq(kw("ASSIGN"), $._assign_pairs),
 
 });

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -168,6 +168,34 @@ bool tree_sitter_abl_external_scanner_scan(
           lexer->advance(lexer, false);
           continue;
         }
+        // The closing quote ends the string, but ABL allows a case-marker
+        // suffix right after it. Consume it here so the ':' cannot be taken
+        // for a block-opening colon, as in
+        //   FOR EACH cust WHERE cust.id = "X":U NO-LOCK:
+        // Accepted shapes: :[RLCT]U?[0-9]* | :U[0-9]* | :[0-9]+
+        lexer->mark_end(lexer);
+        if (lexer->lookahead == ':') {
+          lexer->advance(lexer, false);
+          int marker = lexer->lookahead;
+          bool extended = false;
+          if (marker == 'R' || marker == 'L' || marker == 'C' || marker == 'T' ||
+              marker == 'r' || marker == 'l' || marker == 'c' || marker == 't') {
+            lexer->advance(lexer, false);
+            if (lexer->lookahead == 'U' || lexer->lookahead == 'u') {
+              lexer->advance(lexer, false);
+            }
+            while (iswdigit(lexer->lookahead)) lexer->advance(lexer, false);
+            extended = true;
+          } else if (marker == 'U' || marker == 'u') {
+            lexer->advance(lexer, false);
+            while (iswdigit(lexer->lookahead)) lexer->advance(lexer, false);
+            extended = true;
+          } else if (iswdigit(lexer->lookahead)) {
+            while (iswdigit(lexer->lookahead)) lexer->advance(lexer, false);
+            extended = true;
+          }
+          if (extended) lexer->mark_end(lexer);
+        }
         lexer->result_symbol = ESCAPED_STRING;
         return true;
       }

--- a/test/corpus/statements/browse.txt
+++ b/test/corpus/statements/browse.txt
@@ -830,3 +830,22 @@ DEFINE BROWSE b1 QUERY q1 DISPLAY Name WITH COL 20.
     (column
       column: (identifier))
     column: (number_literal)))
+
+================================================================================
+BROWSE - ENABLE item with a subscript
+================================================================================
+
+DEFINE BROWSE b QUERY q DISPLAY rec ENABLE fld[1] WITH 10 DOWN.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (browse_definition
+    name: (identifier)
+    query: (identifier)
+    (column
+      column: (identifier))
+    field: (array_access
+      array: (identifier)
+      index: (number_literal))
+    down: (number_literal)))

--- a/test/corpus/statements/create-widget.txt
+++ b/test/corpus/statements/create-widget.txt
@@ -109,3 +109,24 @@ END.
       event: (identifier)
       event: (identifier)
       (trigger_body))))
+
+================================================================================
+CREATE WIDGET - NO-ERROR
+================================================================================
+
+CREATE BUTTON hBtn NO-ERROR.
+CREATE WINDOW h ASSIGN x = 1 NO-ERROR.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (create_widget_statement
+    handle: (identifier)
+    (no_error))
+  (create_widget_statement
+    handle: (identifier)
+    (assign_phrase
+      (assign_pair
+        left: (identifier)
+        right: (number_literal)))
+    (no_error)))

--- a/test/corpus/statements/for.txt
+++ b/test/corpus/statements/for.txt
@@ -772,3 +772,27 @@ END.
     (body
       (display_statement
         record: (identifier)))))
+
+================================================================================
+FOR - case-marked string before a block colon
+================================================================================
+
+FOR EACH cust WHERE cust.id = "X":U NO-LOCK:
+  DISPLAY cust.
+END.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (for_statement
+    (record_phrase
+      record: (identifier)
+      where: (binary_expression
+        (qualified_name
+          left: (identifier)
+          right: (identifier))
+        (string_literal))
+      (no_lock))
+    (body
+      (display_statement
+        record: (identifier)))))


### PR DESCRIPTION
Follow-up to #121: the two items you answered there, plus a third we hit afterwards while running the grammar over a production ABL codebase.

Parser deltas are in each commit description. The three together **shrink** the parser:

| | before | after | delta |
|---|---|---|---|
| `ACTION_COUNT` | 39 189 | 38 829 | **−360** |
| `STATE_COUNT` | 31 416 | 31 242 | −174 |
| `LARGE_STATE_COUNT` | 14 904 | 14 777 | −127 |
| `src/parser.c` | 118 438 819 | 117 355 880 | **−1 082 939** |

Corpus: **1104 passing, 0 failing**.

### 1. Subscripted browse ENABLE item

Your suggestion — `array_access` as a field candidate — turned out to be both the fix and a simplification: the special-cased trailing group goes away and the index is labelled.

```
ENABLE fld[1]     before:  field: (identifier)  field: (number_literal)
                  after:   field: (array_access array: (identifier) index: (number_literal))
```

The precedence entry we added in #121 to arbitrate this is dropped with it — regenerating without it produces a byte-identical parser, so it no longer carries weight.

### 2. NO-ERROR on CREATE WIDGET

Your 12.8 test settled it: `ASSIGN x = 1 NO-ERROR` does not compile inside CREATE. The grammar accepted it, and that is what made the trailing NO-ERROR ambiguous. CREATE WIDGET now uses an ASSIGN phrase without NO-ERROR, aliased to `assign_phrase` so the tree is unchanged, and the statement takes the modifier itself.

One judgement call: the pair list is extracted as a shared `_assign_pairs` rather than duplicated. `__assign_pair` carries compound operators, WHEN clauses and the `BROWSE b:attr` form, and a local copy would drift. Happy to duplicate it instead if you prefer the locality convention here.

Not touched: `CREATE SERVER` also takes `assign_phrase`, and we did not check whether NO-ERROR compiles there.

### 3. String case-marker before a block colon — found in production code

This one is not from #121. `"X":U` parses fine alone, but not here:

```abl
FOR EACH cust WHERE cust.id = "X":U NO-LOCK:
```

The suffix was a grammar-level `token.immediate` competing with the block-opening colon, and the colon won: the body opened early, `U` was read as a block label, `NO-LOCK` errored. No corpus case combined a case marker with a block colon, which is why it went unnoticed.

Moving the suffix into the external scanner removes the competition at the source. We validate against six real files from an ERP codebase (38 568 lines); **all six failed on this before, all six now parse with zero errors**. It is also where the megabyte of parser comes from.

We deliberately left the backslash branch in the string scanner alone — our fork removes it, but nothing in our corpus depends on it, so it needs its own evidence rather than riding along here.
