### PR TITLE
grammar: RUN paths and IN WINDOW system handles, found on a production codebase

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -489,6 +489,7 @@ export default grammar({
             ),
             field("name", $._expression),
           ),
+          optional(seq(kw("IN"), field("in_handle", $._identifier_or_qualified_name))),
           optional(seq(kw("AS"), field("type", $._type_name))),
           optional(choice(kw("BY-REFERENCE"), kw("BY-VALUE"), kw("APPEND"), kw("BIND"))),
         ),

--- a/grammar.js
+++ b/grammar.js
@@ -409,7 +409,12 @@ export default grammar({
       _object_access_plain_prefix: ($) =>
         field("left", choice($._object_access_plain_left, $._object_access_expression_left)),
       _object_access_plain_left: ($) =>
-        choice($._identifier_or_qualified_name, $.system_handle_identifier, $.preprocessor_name),
+        choice(
+          $._identifier_or_qualified_name,
+          $.system_handle_identifier,
+          $.preprocessor_name,
+          $.scoped_name,
+        ),
       _object_access_widget_prefix: ($) =>
         seq(
           field("widget", alias($._widgets, $.identifier)),

--- a/grammar.js
+++ b/grammar.js
@@ -525,7 +525,13 @@ export default grammar({
       __widget_qualified_name_separator: ($) => kw("IN"),
 
       _window_handle: ($) =>
-        choice($._identifier_or_qualified_name, $.object_access, $.function_call, $.scoped_name),
+        choice(
+          $._identifier_or_qualified_name,
+          $.system_handle_identifier,
+          $.object_access,
+          $.function_call,
+          $.scoped_name,
+        ),
 
       // Identifiers
       // BE CAREFUL MODIFYING HERE, IDENTIFIER ORDER FOR SOME REASON MATTERS!

--- a/grammar/core/common.js
+++ b/grammar/core/common.js
@@ -192,7 +192,7 @@ export default ({ kw }) => ({
           $.argument_reference,
           alias($._like_phrase, $.like_phrase),
           alias($.__temp_table_like_sequential_phrase, $.like_sequential_phrase),
-          alias(kw("RCODE-INFORMATION"), $.rcode_information),
+          alias(kw("RCODE-INFORMATION", { offset: 10 }), $.rcode_information),
           alias($.__temp_table_before_table_phrase, $.before_table_phrase),
         ),
       ),

--- a/grammar/phrases/record.js
+++ b/grammar/phrases/record.js
@@ -49,8 +49,10 @@ export default ({ kw }) => ({
   __record_except_list: ($) => seq(kw("EXCEPT"), $.__record_parenthesized_field_names),
   __record_parenthesized_field_names: ($) => seq("(", optional($.__record_field_names), ")"),
   __record_field_names: ($) =>
+    seq($.__record_field_name, repeat(seq(optional(","), $.__record_field_name))),
+  __record_field_name: ($) =>
     seq(
       $._identifier_or_qualified_name,
-      repeat(seq(optional(","), $._identifier_or_qualified_name)),
+      optional(seq("[", field("index", $._expression), "]")),
     ),
 });

--- a/grammar/statements/create.js
+++ b/grammar/statements/create.js
@@ -29,7 +29,7 @@ export default ({ kw }) => ({
   __create_buffer: ($) =>
     seq(
       kw("BUFFER"),
-      field("handle", $.identifier),
+      field("handle", $._identifier_or_array_access),
       kw("FOR"),
       kw("TABLE"),
       field("table", $.__create_buffer_target),

--- a/grammar/statements/delete.js
+++ b/grammar/statements/delete.js
@@ -14,7 +14,10 @@ export default ({ kw }) => ({
     seq(
       kw("DELETE"),
       kw("OBJECT"),
-      field("name", choice($.identifier, $.parenthesized_expression)),
+      field(
+        "name",
+        choice($._identifier_or_array_access, $.system_handle_identifier, $.parenthesized_expression),
+      ),
     ),
 
   delete_procedure_statement: ($) => seq($.__delete_procedure_prefix, $._no_error_terminator),

--- a/grammar/statements/function.js
+++ b/grammar/statements/function.js
@@ -49,6 +49,13 @@ export default ({ kw }) => ({
       kw("RETURNS", { offset: 5 }),
       optional(kw("CLASS")),
       field("type", $._type_name),
+      optional(
+        choice(
+          alias(kw("PRIVATE"), $.access_modifier),
+          alias(kw("PROTECTED"), $.access_modifier),
+          alias(kw("PUBLIC"), $.access_modifier),
+        ),
+      ),
       optional(alias($.__function_parameters, $.parameters)),
     ),
 

--- a/grammar/statements/run.js
+++ b/grammar/statements/run.js
@@ -35,10 +35,16 @@ export default ({ kw }) => ({
       alias($._value_expression, $.value_expression),
       alias($.__run_library_member, $.library_member),
       $.procedure_name,
+      alias($.__run_procedure_path, $.procedure_name),
       $.macro_concatenated_name,
       $.identifier,
       $.qualified_name,
     ),
+  // A procedure reference given as a path, with the .p or .r extension left
+  // implicit: RUN Erp\Model\Vente\ErpTrt. Both separators occur in practice.
+  __run_procedure_path: ($) =>
+    token(/[A-Za-z_][A-Za-z0-9_-]*(?:[/\u005C][A-Za-z_][A-Za-z0-9_-]*)+/),
+
   __run_library_member: ($) =>
     seq(
       field("library", $.procedure_name),

--- a/grammar/statements/temp-table.js
+++ b/grammar/statements/temp-table.js
@@ -116,6 +116,10 @@ export default ({ kw }) => ({
       ),
       alias(kw("SHARED"), $.scope_modifier),
       seq(
+        alias(kw("STATIC"), $.static_modifier),
+        optional($._serialization_modifier),
+      ),
+      seq(
         choice(alias(kw("PRIVATE"), $.access_modifier), alias(kw("PROTECTED"), $.access_modifier)),
         optional(alias(kw("STATIC"), $.static_modifier)),
         optional($._serialization_modifier),

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -154,14 +154,6 @@ bool tree_sitter_abl_external_scanner_scan(
     lexer->advance(lexer, false);
 
     while (!lexer->eof(lexer)) {
-      if (lexer->lookahead == '\\') {
-        lexer->advance(lexer, false);
-        if (!lexer->eof(lexer)) {
-          lexer->advance(lexer, false);
-        }
-        continue;
-      }
-
       if (lexer->lookahead == start) {
         lexer->advance(lexer, false);
         if (lexer->lookahead == start) {

--- a/test/corpus/phrases/record.txt
+++ b/test/corpus/phrases/record.txt
@@ -13,3 +13,24 @@ PRESELECT EACH Customer NO-LOCK.
         (record_phrase
           record: (identifier)
           (no_lock))))))
+
+================================================================================
+FOR - FIELDS list with array subscripts
+================================================================================
+
+FOR FIRST t FIELDS (secta[1] sect[2]) NO-LOCK:
+END.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (for_statement
+    (record_phrase
+      record: (identifier)
+      (field_list
+        (identifier)
+        index: (number_literal)
+        (identifier)
+        index: (number_literal))
+      (no_lock))
+    (body)))

--- a/test/corpus/statements/create.txt
+++ b/test/corpus/statements/create.txt
@@ -312,3 +312,23 @@ CREATE BUFFER h FOR TABLE "t" IN WIDGET-POOL "myPool".
     handle: (identifier)
     table: (string_literal)
     pool: (string_literal)))
+
+================================================================================
+CREATE BUFFER - handle held in an array or a field
+================================================================================
+
+CREATE BUFFER hb[i] FOR TABLE r.nom_table BUFFER-NAME r.nom_alias.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (create_statement
+    handle: (array_access
+      array: (identifier)
+      index: (identifier))
+    table: (qualified_name
+      left: (identifier)
+      right: (identifier))
+    name: (qualified_name
+      left: (identifier)
+      right: (identifier))))

--- a/test/corpus/statements/delete.txt
+++ b/test/corpus/statements/delete.txt
@@ -172,3 +172,17 @@ DELETE Customer VALIDATE(NOT(CAN-FIND(Order OF Customer)),
           (of_phrase
             record: (identifier)))))
     message: (string_literal)))
+
+================================================================================
+DELETE OBJECT - handle held in an array
+================================================================================
+
+DELETE OBJECT hb[vii].
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (delete_object_statement
+    name: (array_access
+      array: (identifier)
+      index: (identifier))))

--- a/test/corpus/statements/expression.txt
+++ b/test/corpus/statements/expression.txt
@@ -158,3 +158,24 @@ y = REPLACE(v,"\","_").
           name: (string_literal))
         (argument
           name: (string_literal))))))
+
+================================================================================
+ARGUMENT - IN handle qualifier
+================================================================================
+
+x = DYNAMIC-FUNCTION("Verif":U IN api, 24).
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (assignment_statement
+    left: (identifier)
+    operator: (assignment_operator)
+    right: (function_call
+      function: (identifier)
+      (arguments
+        (argument
+          name: (string_literal)
+          in_handle: (identifier))
+        (argument
+          name: (number_literal))))))

--- a/test/corpus/statements/expression.txt
+++ b/test/corpus/statements/expression.txt
@@ -131,3 +131,30 @@ x = arr[1]:HANDLE.
         array: (identifier)
         index: (number_literal))
       right: (identifier))))
+
+================================================================================
+STRING - backslash is an ordinary character
+================================================================================
+
+x = "C:\temp\fichier.txt".
+y = REPLACE(v,"\","_").
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (assignment_statement
+    left: (identifier)
+    operator: (assignment_operator)
+    right: (string_literal))
+  (assignment_statement
+    left: (identifier)
+    operator: (assignment_operator)
+    right: (function_call
+      function: (identifier)
+      (arguments
+        (argument
+          name: (identifier))
+        (argument
+          name: (string_literal))
+        (argument
+          name: (string_literal))))))

--- a/test/corpus/statements/expression.txt
+++ b/test/corpus/statements/expression.txt
@@ -179,3 +179,21 @@ x = DYNAMIC-FUNCTION("Verif":U IN api, 24).
           in_handle: (identifier))
         (argument
           name: (number_literal))))))
+
+================================================================================
+OBJECT ACCESS - scoped name as the receiver
+================================================================================
+
+x = h::champ:ATTR.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (assignment_statement
+    left: (identifier)
+    operator: (assignment_operator)
+    right: (object_access
+      left: (scoped_name
+        left: (identifier)
+        right: (identifier))
+      right: (identifier))))

--- a/test/corpus/statements/function.txt
+++ b/test/corpus/statements/function.txt
@@ -822,3 +822,22 @@ FUNCTION j RETURNS CHARACTER (DATASET-HANDLE hd) FORWARD.
       (parameter
         dataset_handle: (identifier)))
     (forward)))
+
+================================================================================
+FUNCTION FORWARD - access modifier
+================================================================================
+
+FUNCTION f RETURNS DECIMAL PRIVATE (INPUT p AS CHARACTER) FORWARD.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (function_forward_definition
+    name: (identifier)
+    type: (identifier)
+    (access_modifier)
+    (parameters
+      (parameter
+        name: (identifier)
+        type: (identifier)))
+    (forward)))

--- a/test/corpus/statements/message.txt
+++ b/test/corpus/statements/message.txt
@@ -518,3 +518,19 @@ MESSAGE "x" VIEW-AS ALERT-BOX TITLE cTitle.
     (string_literal)
     (view_as_phrase
       title: (identifier))))
+
+================================================================================
+MESSAGE - IN WINDOW with a system handle
+================================================================================
+
+MESSAGE "x" VIEW-AS ALERT-BOX INFORMATION BUTTONS OK IN WINDOW CURRENT-WINDOW.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (message_statement
+    (string_literal)
+    (view_as_phrase
+      (alert_type))
+    (in_window_phrase
+      window: (identifier))))

--- a/test/corpus/statements/run.txt
+++ b/test/corpus/statements/run.txt
@@ -518,3 +518,20 @@ RUN p IN hArr[1].
       context: (array_access
         array: (identifier)
         index: (number_literal)))))
+
+================================================================================
+RUN - procedure path without an extension
+================================================================================
+
+RUN externe/ext-truc.
+RUN Erp\Model\Vente\ErpTrt PERSISTENT SET h.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (run_statement
+    procedure: (procedure_name))
+  (run_statement
+    procedure: (procedure_name)
+    (persistent
+      handle: (identifier))))

--- a/test/corpus/statements/temp-table.txt
+++ b/test/corpus/statements/temp-table.txt
@@ -730,3 +730,20 @@ DEFINE TEMP-TABLE tt NO-UNDO RCODE-INFO FIELD f AS INTEGER.
     (temp_table_field
       name: (identifier)
       type: (identifier))))
+
+================================================================================
+TEMP-TABLE - STATIC without an access modifier
+================================================================================
+
+DEFINE STATIC TEMP-TABLE tt NO-UNDO FIELD f AS INTEGER.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (temp_table_definition
+    (static_modifier)
+    name: (identifier)
+    (no_undo)
+    (temp_table_field
+      name: (identifier)
+      type: (identifier))))

--- a/test/corpus/statements/temp-table.txt
+++ b/test/corpus/statements/temp-table.txt
@@ -713,3 +713,20 @@ WAIT-FOR CHOOSE OF cancel-butt OR WINDOW-CLOSE OF CURRENT-WINDOW.
       events: (identifier)
       widgets: (widget_phrase
         system_handle: (system_handle)))))
+
+================================================================================
+TEMP-TABLE - RCODE-INFO abbreviation
+================================================================================
+
+DEFINE TEMP-TABLE tt NO-UNDO RCODE-INFO FIELD f AS INTEGER.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (temp_table_definition
+    name: (identifier)
+    (no_undo)
+    (rcode_information)
+    (temp_table_field
+      name: (identifier)
+      type: (identifier))))


### PR DESCRIPTION
Eleven fixes found by running the grammar over a production ABL codebase (an ERP, ~16k files) rather than by writing probes. Each commit carries its own parser deltas.

### Measured effect

We validate against two directories of that codebase:

| | before | after |
|---|---|---|
| 141 REST/integration procedures | 87 pass | **141 pass (100%)** |
| 269 model/API classes | 227 pass | **249 pass** |
| combined | 314 / 410 (76.6%) | **390 / 410 (95.1%)** |

Corpus: **1115 passing, 0 failing**.

Whole branch: `ACTION_COUNT` 38 829 → 39 188 (+359, +0.9%), `src/parser.c` +800 446 bytes.

### What is in

| Fix | ACTION_COUNT |
|---|---|
| `RUN` target given as a path, extension implicit | +2 |
| system handle as an `IN WINDOW` target | +4 |
| backslash is an ordinary string character | 0 |
| array subscripts in a `FIELDS` list | +43 |
| qualified or subscripted `CREATE BUFFER` handle | −2 |
| array element in `DELETE OBJECT` | −2 |
| `RCODE-INFO` abbreviation | 0 |
| `STATIC` alone as a temp-table modifier | 0 |
| access modifier on a `FORWARD` function | +10 |
| `IN handle` qualifier on a call argument | +32 |
| scoped name as an object access receiver | **+272** |

The last one is worth your attention: it is six times the next highest, and the receiver is clearly a hot spot in the tables. If you would rather have a narrower formulation, say so.

Three commits cost nothing at all, and two make the parser smaller.

### A pattern worth noting

Several of these are asymmetries between paths that should agree:

- `PUT SCREEN … COL` accepted the abbreviation, `PUT CURSOR … COL` did not (fixed in #120).
- `FUNCTION … PRIVATE (…)` with a body was accepted; the same with `FORWARD` was not.
- `h::field` parsed, `h:attr` parsed, `h::field:attr` did not.
- `RCODE-INFORMATION` parsed, `RCODE-INFO` did not.

They are invisible when testing construct by construct, and obvious the moment real code goes through.

### Two things we did not fix — questions

**1. `RUN … IN THIS-OBJECT:handle`**

```abl
RUN OperationsCommerciales IN THIS-OBJECT:hGco(pCodCli, OUTPUT vCodOp).
```

`RUN … IN vObj:h` parses and `RUN … IN THIS-OBJECT` parses, but not the two together: in `__run_context_value` the `alias(kw("THIS-OBJECT"), $.this_object)` alternative takes the handle and the object-access path never gets it. Dropping those two aliases would fix it but changes `RUN … IN THIS-OBJECT.` from `(this_object)` to a plain identifier, which is a tree decision we did not want to take for you. Which shape do you want?

**2. `System.Windows.Forms.Control+ControlCollection`**

A .NET nested type in a `DEFINE VARIABLE … AS`. The quoted form `"System.Control+Collection"` already parses, so there is a workaround, and `+` in a type name competes with the additive operator. Worth supporting, or leave it?

### Also worth knowing

About a third of the residual failures in the class directory are not grammar at all: those files get their `CLASS` header from a parameterised include, and our harness does not resolve includes across the workspace propath. We are fixing that on our side; the 249/269 above therefore understates the grammar.
