### PR TITLE
grammar: AppBuilder-generated screens, plus the two answers from #123

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -371,6 +371,7 @@ export default grammar({
           $.array_access,
           $.function_call,
           $.system_handle_identifier,
+          $.preprocessor_name,
         ),
 
       // Expressions

--- a/grammar/expressions/can-find.js
+++ b/grammar/expressions/can-find.js
@@ -38,18 +38,25 @@ export default ({ kw }) => ({
   __record_query_after_frame: ($) =>
     choice($.__record_query_where_or_lock, $.__record_query_use_index),
   __record_query_where_or_lock: ($) =>
-    seq(
-      choice(
-        seq(
-          alias($.__record_query_where_phrase, $.where_phrase),
-          optional(alias($.__record_query_lock_phrase, $.no_lock)),
-        ),
-        seq(
-          alias($.__record_query_lock_phrase, $.no_lock),
-          optional(alias($.__record_query_where_phrase, $.where_phrase)),
+    choice(
+      seq(
+        alias($.__record_query_where_phrase, $.where_phrase),
+        choice(
+          seq(
+            optional(alias($.__record_query_lock_phrase, $.no_lock)),
+            optional($.__record_query_use_index),
+          ),
+          seq(
+            $.__record_query_use_index,
+            optional(alias($.__record_query_lock_phrase, $.no_lock)),
+          ),
         ),
       ),
-      optional($.__record_query_use_index),
+      seq(
+        alias($.__record_query_lock_phrase, $.no_lock),
+        optional(alias($.__record_query_where_phrase, $.where_phrase)),
+        optional($.__record_query_use_index),
+      ),
     ),
 
   __record_query_where_phrase: ($) => seq(kw("WHERE"), optional($._expression)),

--- a/grammar/phrases/editor.js
+++ b/grammar/phrases/editor.js
@@ -2,21 +2,20 @@ export default ({ kw }) => ({
   editor_phrase: ($) =>
     seq(
       kw("EDITOR"),
+      repeat($.__editor_option),
       $.__editor_size,
-      optional(
-        repeat1(
-          choice(
-            seq(kw("BUFFER-CHARS"), field("buffer_chars", $.number_literal)),
-            seq(kw("BUFFER-LINES"), field("buffer_lines", $.number_literal)),
-            alias(kw("LARGE"), $.large),
-            seq(kw("MAX-CHARS"), field("max_chars", $.number_literal)),
-            alias(kw("NO-BOX"), $.no_box),
-            alias(kw("NO-WORD-WRAP"), $.no_word_wrap),
-            $._scrollbar_option,
-            $._tooltip_phrase,
-          ),
-        ),
-      ),
+      repeat($.__editor_option),
+    ),
+  __editor_option: ($) =>
+    choice(
+      seq(kw("BUFFER-CHARS"), field("buffer_chars", $.number_literal)),
+      seq(kw("BUFFER-LINES"), field("buffer_lines", $.number_literal)),
+      alias(kw("LARGE"), $.large),
+      seq(kw("MAX-CHARS"), field("max_chars", $.number_literal)),
+      alias(kw("NO-BOX"), $.no_box),
+      alias(kw("NO-WORD-WRAP"), $.no_word_wrap),
+      $._scrollbar_option,
+      $._tooltip_phrase,
     ),
   __editor_size: ($) =>
     choice(

--- a/grammar/phrases/widget.js
+++ b/grammar/phrases/widget.js
@@ -8,7 +8,8 @@ export default ({ kw }) => ({
       seq(choice(kw("MENU"), kw("SUB-MENU")), field("menu", $.identifier)),
     ),
 
-  __widget_handle: ($) => seq(field("handle", $._identifier_or_qualified_name)),
+  __widget_handle: ($) =>
+    seq(field("handle", choice($._identifier_or_qualified_name, $.preprocessor_name))),
 
   __widget_entry: ($) =>
     choice(

--- a/grammar/statements/browse.js
+++ b/grammar/statements/browse.js
@@ -39,6 +39,8 @@ export default ({ kw }) => ({
           seq(kw("FGCOLOR"), field("fgcolor", $.__browse_option_expression)),
           seq(kw("FONT"), field("font", $.__browse_option_expression)),
           seq(kw("PFCOLOR"), field("pfcolor", $.__browse_option_expression)),
+          seq(kw("ROW-HEIGHT-CHARS"), field("row_height_chars", $.__browse_option_expression)),
+          seq(kw("ROW-HEIGHT-PIXELS"), field("row_height_pixels", $.__browse_option_expression)),
           seq(
             kw("TITLE"),
             optional($._frame_title_option),

--- a/grammar/statements/create-temp-table.js
+++ b/grammar/statements/create-temp-table.js
@@ -4,7 +4,7 @@ export default ({ kw }) => ({
   __create_temp_table_body: ($) =>
     seq(
       kw("TEMP-TABLE"),
-      field("handle", $.identifier),
+      field("handle", choice($._identifier_or_array_access, $.object_access)),
       optional(alias($._in_widget_pool, $.in_widget_pool_phrase)),
     ),
 });

--- a/grammar/statements/delete.js
+++ b/grammar/statements/delete.js
@@ -16,7 +16,12 @@ export default ({ kw }) => ({
       kw("OBJECT"),
       field(
         "name",
-        choice($._identifier_or_array_access, $.system_handle_identifier, $.parenthesized_expression),
+        choice(
+          $._identifier_or_array_access,
+          $.system_handle_identifier,
+          $.object_access,
+          $.parenthesized_expression,
+        ),
       ),
     ),
 

--- a/grammar/statements/run.js
+++ b/grammar/statements/run.js
@@ -74,8 +74,7 @@ export default ({ kw }) => ({
 
   __run_context_value: ($) =>
     choice(
-      alias(kw("THIS-PROCEDURE"), $.this_procedure),
-      alias(kw("THIS-OBJECT"), $.this_object),
+      $.system_handle_identifier,
       $.object_access,
       $.array_access,
       $._identifier_or_qualified_name,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -275,8 +275,6 @@
   (table_scan)
   (terminal)
   (text)
-  (this_object)
-  (this_procedure)
   (thread_safe)
   (three_d)
   (transaction)

--- a/test/corpus/phrases/editor.txt
+++ b/test/corpus/phrases/editor.txt
@@ -41,3 +41,23 @@ DEFINE VARIABLE x AS CHARACTER VIEW-AS EDITOR INNER-CHARS 60 INNER-LINES 5.
       (editor_phrase
         inner_chars: (number_literal)
         inner_lines: (number_literal)))))
+
+================================================================================
+EDITOR - options before the size
+================================================================================
+
+DEFINE VARIABLE v AS CHARACTER VIEW-AS EDITOR SCROLLBAR-VERTICAL SIZE 10 BY 2 NO-UNDO.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (variable_definition
+    name: (identifier)
+    type: (identifier)
+    (view_as_phrase
+      (editor_phrase
+        (scrollbar_vertical)
+        (size_phrase
+          width: (number_literal)
+          height: (number_literal))))
+    (no_undo)))

--- a/test/corpus/statements/browse.txt
+++ b/test/corpus/statements/browse.txt
@@ -849,3 +849,21 @@ DEFINE BROWSE b QUERY q DISPLAY rec ENABLE fld[1] WITH 10 DOWN.
       array: (identifier)
       index: (number_literal))
     down: (number_literal)))
+
+================================================================================
+BROWSE - ROW-HEIGHT-CHARS option
+================================================================================
+
+DEFINE BROWSE b QUERY q DISPLAY f WITH 10 DOWN ROW-HEIGHT-CHARS .54 FIT-LAST-COLUMN.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (browse_definition
+    name: (identifier)
+    query: (identifier)
+    (column
+      column: (identifier))
+    down: (number_literal)
+    row_height_chars: (number_literal)
+    (fit_last_column)))

--- a/test/corpus/statements/create.txt
+++ b/test/corpus/statements/create.txt
@@ -332,3 +332,17 @@ CREATE BUFFER hb[i] FOR TABLE r.nom_table BUFFER-NAME r.nom_alias.
     name: (qualified_name
       left: (identifier)
       right: (identifier))))
+
+================================================================================
+CREATE TEMP-TABLE - handle held in an array
+================================================================================
+
+CREATE TEMP-TABLE hTT[1].
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (create_temp_table_statement
+    handle: (array_access
+      array: (identifier)
+      index: (number_literal))))

--- a/test/corpus/statements/delete.txt
+++ b/test/corpus/statements/delete.txt
@@ -186,3 +186,17 @@ DELETE OBJECT hb[vii].
     name: (array_access
       array: (identifier)
       index: (identifier))))
+
+================================================================================
+DELETE OBJECT - object attribute
+================================================================================
+
+DELETE OBJECT THIS-OBJECT:gData.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (delete_object_statement
+    name: (object_access
+      left: (identifier)
+      right: (identifier))))

--- a/test/corpus/statements/expression.txt
+++ b/test/corpus/statements/expression.txt
@@ -197,3 +197,18 @@ x = h::champ:ATTR.
         left: (identifier)
         right: (identifier))
       right: (identifier))))
+
+================================================================================
+ASSIGNMENT - preprocessor name as the target
+================================================================================
+
+{&WINDOW-NAME} = CURRENT-WINDOW.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (assignment_statement
+    left: (preprocessor_name
+      (identifier))
+    operator: (assignment_operator)
+    right: (identifier)))

--- a/test/corpus/statements/if.txt
+++ b/test/corpus/statements/if.txt
@@ -509,3 +509,25 @@ IF x > 0 THEN procedure = 1.
       left: (identifier)
       operator: (assignment_operator)
       right: (number_literal))))
+
+================================================================================
+CAN-FIND - USE-INDEX before NO-LOCK
+================================================================================
+
+IF CAN-FIND(FIRST t WHERE t.a = 1 USE-INDEX ix NO-LOCK) THEN RETURN.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (if_statement
+    (can_find_expression
+      table: (identifier)
+      (where_phrase
+        (binary_expression
+          (qualified_name
+            left: (identifier)
+            right: (identifier))
+          (number_literal)))
+      index: (identifier)
+      (no_lock))
+    then: (return_statement)))

--- a/test/corpus/statements/on.txt
+++ b/test/corpus/statements/on.txt
@@ -513,3 +513,24 @@ END.
         handle: (identifier)))
     (do_statement
       (body))))
+
+================================================================================
+ON - preprocessor name as the widget
+================================================================================
+
+ON WINDOW-CLOSE, ENDKEY OF {&WINDOW-NAME} ANYWHERE DO:
+END.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (on_statement
+    event: (identifier)
+    event: (identifier)
+    (of_phrase
+      widget: (widget_phrase
+        handle: (preprocessor_name
+          (identifier))))
+    (anywhere)
+    (do_statement
+      (body))))

--- a/test/corpus/statements/run.txt
+++ b/test/corpus/statements/run.txt
@@ -285,7 +285,7 @@ RUN methodProc IN hProc NO-ERROR.
     (asynchronous_phrase
       handle: (identifier)
       event_handler: (string_literal)
-      context: (this_procedure))
+      context: (identifier))
     (arguments
       (argument
         name: (identifier))
@@ -399,7 +399,7 @@ RUN methodProc IN hProc NO-ERROR.
       context: (identifier))
     (asynchronous_phrase
       event_procedure: (string_literal)
-      context: (this_procedure)))
+      context: (identifier)))
   (run_statement
     procedure: (identifier)
     (in_phrase
@@ -535,3 +535,24 @@ RUN Erp\Model\Vente\ErpTrt PERSISTENT SET h.
     procedure: (procedure_name)
     (persistent
       handle: (identifier))))
+
+================================================================================
+RUN - IN with an attribute of THIS-OBJECT
+================================================================================
+
+RUN Oper IN THIS-OBJECT:hGco(a, INPUT b).
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (run_statement
+    procedure: (identifier)
+    (in_phrase
+      context: (object_access
+        left: (identifier)
+        right: (identifier)))
+    (arguments
+      (argument
+        name: (identifier))
+      (argument
+        name: (identifier)))))


### PR DESCRIPTION
Eight fixes, continuing the corpus-driven work from #123. Deltas are in each commit; the branch totals `ACTION_COUNT` 39 188 → 39 424 (+236).

Corpus: **1123 passing, 0 failing**.

Two of these answer the questions you left open in #123 — thank you for both.

### Answering #123

**`RUN … IN THIS-OBJECT:handle`** — you said it is reasonable for this-object to become an identifier, so the two dedicated alternatives in `__run_context_value` are gone in favour of `system_handle_identifier`. Two expectations in the RUN corpus move from `(this_procedure)` to `(identifier)`; the other six context fields in that file already read `(identifier)`. `this_object` and `this_procedure` are removed from `highlights.scm` since nothing produces them any more. The commit makes the parser smaller.

**The .NET nested type** — we are leaving it. One file in a 16k-file codebase uses it, the quoted form already parses, and neither of us is sure what the syntax covers. A rule we do not understand seems worse than a gap we do.

### The rest

| Fix | ACTION_COUNT |
|---|---|
| object attribute in `DELETE OBJECT` | 0 |
| `USE-INDEX` before `NO-LOCK` in `CAN-FIND` | +2 |
| EDITOR options before the size | +215 |
| array element or attribute as `CREATE TEMP-TABLE` handle | −2 |
| preprocessor name as an assignment target | +8 |
| `ROW-HEIGHT-CHARS` / `ROW-HEIGHT-PIXELS` on a browse | +18 |
| preprocessor name as a widget handle | +8 |

### A pattern, more useful than the individual fixes

We ran the grammar over ~2 700 AppBuilder-generated screens. They parse far worse than hand-written code — 19% against 93–97% for classes — and the reason is consistent: **the generator parameterises every handle through a macro**, and the grammar expects an identifier in those positions.

Three of the commits here are the same one-line shape in three places: assignment target, object access receiver, widget handle. There are almost certainly more. If you would rather have a shared rule that says "a name, or a macro standing in for one", that would close the class instead of the instances — happy to prepare it if you tell us where you would want it to live.

`ROW-HEIGHT-CHARS` and `ROW-HEIGHT-PIXELS` were simply absent from the grammar; the language reference documents both.

### Honest measurement note

On a 700-file sample of that codebase these eight fixes take the total error count down 23% (19 193 → 14 720) but move the file pass rate only from 42.3% to 43.0%. Generated screens are long and hit several distinct gaps each, so they need many fixes before any single file flips. We report both numbers because the file rate alone would understate the progress, and the error count alone would overstate it.
