### PR TITLE
grammar: AppBuilder screens, round 2 — 42% to 60% on generated code

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -263,6 +263,10 @@ export default grammar({
 
       // Constants
       constant: ($) => token(prec(-1, /\{&[^}\r\n]+\}[ \t]*\r?\n/)),
+      // A macro alone on its line expands to whole statements, terminator included,
+      // so none follows it in the source. It outranks `{` to win in statement
+      // position; anywhere else `{` still opens a preprocessor_name.
+      __macro_statement: ($) => token(prec(2, /\{&[^}\r\n]+\}[ \t]*\r?\n/)),
       preprocessor_name: ($) =>
         prec(
           1,

--- a/grammar/core/statements.js
+++ b/grammar/core/statements.js
@@ -5,6 +5,7 @@ export default ({ kw }) => ({
     choice(
       // Special
       alias($.include_statement, $.include_file_reference),
+      alias($.__macro_statement, $.constant),
       $.global_define_preprocessor_directive,
       $.scoped_define_preprocessor_directive,
       alias($.if_preprocessor_directive_statement, $.if_preprocessor_directive),

--- a/grammar/phrases/at.js
+++ b/grammar/phrases/at.js
@@ -16,7 +16,7 @@ export default ({ kw }) => ({
     repeat1(
       choice(
         seq(
-          kw("COLUMN"),
+          kw("COLUMN", { offset: 3 }),
           choice(field("column", $._expression), alias($.__at_of_suffix, $.column_of)),
         ),
         seq(kw("COLUMN-OF"), field("column_of", $._expression)),

--- a/grammar/phrases/frame.js
+++ b/grammar/phrases/frame.js
@@ -78,7 +78,9 @@ export default ({ kw }) => ({
       seq(kw("FONT"), field("title_font", $.__frame_expression)),
     ),
   __frame_column_keyword: ($) => choice(kw("COLUMN"), kw("COLUMNS"), kw("COL")),
-  __frame_identifier: ($) => $.identifier,
+  // Generated screens name their frame, browse and window through a macro, as in
+  // `WITH FRAME {&FRAME-NAME}`, so a name here can be either.
+  __frame_identifier: ($) => choice($.identifier, $.preprocessor_name),
   __frame_expression: ($) => $._expression,
   down: ($) =>
     choice(

--- a/grammar/phrases/image.js
+++ b/grammar/phrases/image.js
@@ -1,7 +1,7 @@
 export default ({ kw }) => ({
   image_phrase: ($) =>
     seq(
-      kw("FILE"),
+      choice(kw("FILE"), kw("FILENAME")),
       field("file", $._expression),
       optional(
         seq(

--- a/grammar/phrases/widget.js
+++ b/grammar/phrases/widget.js
@@ -1,12 +1,16 @@
 export default ({ kw }) => ({
   widget_phrase: ($) =>
     choice(
-      seq(kw("FRAME"), field("frame", $.identifier)),
-      seq(kw("BROWSE"), field("browse", $.identifier)),
+      seq(kw("FRAME"), field("frame", $.__widget_name)),
+      seq(kw("BROWSE"), field("browse", $.__widget_name)),
       $.__widget_handle,
       $.__widget_entry,
-      seq(choice(kw("MENU"), kw("SUB-MENU")), field("menu", $.identifier)),
+      seq(choice(kw("MENU"), kw("SUB-MENU")), field("menu", $.__widget_name)),
     ),
+
+  // Generated screens reach their widgets through a macro — `OF FRAME
+  // {&FRAME-NAME}`, `IN BROWSE {&BROWSE-NAME}` — so a name here can be either.
+  __widget_name: ($) => choice($.identifier, $.preprocessor_name),
 
   __widget_handle: ($) =>
     seq(field("handle", choice($._identifier_or_qualified_name, $.preprocessor_name))),
@@ -16,16 +20,16 @@ export default ({ kw }) => ({
       seq(
         optional(kw("FIELD")),
         field("field", $._identifier_or_array_access),
-        optional(seq(kw("IN"), kw("FRAME"), field("frame", $.identifier))),
+        optional(seq(kw("IN"), kw("FRAME"), field("frame", $.__widget_name))),
       ),
       seq(
         field("column", $._identifier_or_array_access),
-        seq(kw("IN"), kw("BROWSE"), field("browse", $.identifier)),
+        seq(kw("IN"), kw("BROWSE"), field("browse", $.__widget_name)),
       ),
       seq(
         kw("MENU-ITEM"),
         field("item", $._identifier_or_qualified_name),
-        optional(seq(kw("IN"), kw("MENU"), field("menu", $.identifier))),
+        optional(seq(kw("IN"), kw("MENU"), field("menu", $.__widget_name))),
       ),
       field("system_handle", alias($.__widget_system_handle, $.system_handle)),
     ),

--- a/grammar/statements/create.js
+++ b/grammar/statements/create.js
@@ -38,7 +38,15 @@ export default ({ kw }) => ({
       ),
       optional($._in_widget_pool),
     ),
-  __create_buffer_target: ($) => choice($._identifier_or_access_or_call, $.string_literal),
+  // The table is named by a character expression, so it can be assembled at run
+  // time. Concatenation is spelled out here rather than reusing the expression
+  // rule: that one reaches widget_qualified_name, whose separator is IN, and it
+  // would then swallow the IN WIDGET-POOL option that follows.
+  __create_buffer_target: ($) =>
+    choice($.__create_buffer_name, alias($.__create_buffer_concatenation, $.binary_expression)),
+  __create_buffer_concatenation: ($) =>
+    seq($.__create_buffer_name, repeat1(seq("+", $.__create_buffer_name))),
+  __create_buffer_name: ($) => choice($._identifier_or_access_or_call, $.string_literal),
   __create_handle_with_pool_no_error_body: ($) =>
     seq(
       choice(kw("CALL"), kw("QUERY"), kw("SAX-READER"), kw("SAX-WRITER"), kw("SAX-ATTRIBUTES")),

--- a/grammar/statements/delete-widget-pool.js
+++ b/grammar/statements/delete-widget-pool.js
@@ -1,6 +1,10 @@
 export default ({ kw }) => ({
-  delete_widget_pool_statement: ($) => seq($.__delete_widget_pool_prefix, $._terminator),
+  delete_widget_pool_statement: ($) => seq($.__delete_widget_pool_prefix, $._no_error_terminator),
 
   __delete_widget_pool_prefix: ($) =>
-    seq(kw("DELETE"), kw("WIDGET-POOL"), optional(field("pool", $.identifier))),
+    seq(
+      kw("DELETE"),
+      kw("WIDGET-POOL"),
+      optional(field("pool", choice($.identifier, $.string_literal))),
+    ),
 });

--- a/grammar/statements/function.js
+++ b/grammar/statements/function.js
@@ -99,6 +99,10 @@ export default ({ kw }) => ({
         seq(kw("TABLE-HANDLE"), field("table_handle", $.identifier)),
         seq(kw("DATASET"), kw("FOR"), field("dataset", $._identifier_or_qualified_name)),
         seq(kw("DATASET-HANDLE"), field("dataset_handle", $.identifier)),
+        // A prototype states only the mode and data type of each parameter, so the
+        // name may be absent. Definition and prototype share every token up to the
+        // closing parenthesis, so one rule has to serve both.
+        seq(optional(kw("CLASS")), field("type", $._type_name), optional($._extent_phrase)),
       ),
     ),
 

--- a/test/corpus/core/preprocessor.txt
+++ b/test/corpus/core/preprocessor.txt
@@ -143,3 +143,25 @@ PREPROCESSOR IF DIRECTIVES - mixed with statements
     type: (identifier))
   (if_preprocessor_directive
     (endif_branch)))
+
+================================================================================
+PREPROCESSOR - macro alone on its line is a statement
+================================================================================
+
+DEFINE VARIABLE x AS INTEGER NO-UNDO.
+{&FetchDyn}
+ASSIGN x = 1.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (variable_definition
+    name: (identifier)
+    type: (identifier)
+    (no_undo))
+  (constant)
+  (assign_statement
+    (assign_phrase
+      (assign_pair
+        left: (identifier)
+        right: (number_literal)))))

--- a/test/corpus/phrases/at.txt
+++ b/test/corpus/phrases/at.txt
@@ -37,3 +37,21 @@ FORM "Label" AT ROW 2 COLUMN 3.
       field: (identifier))
     (form_item
       field: (number_literal))))
+
+================================================================================
+AT - COLUMN abbreviated to COL
+================================================================================
+
+DEFINE FRAME F1 WITH NO-BOX OVERLAY AT COL 1 ROW 1.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (frame_definition
+    name: (identifier)
+    (frame_phrase
+      (no_box)
+      (overlay)
+      (at_phrase
+        column: (number_literal))
+      row: (number_literal))))

--- a/test/corpus/phrases/frame.txt
+++ b/test/corpus/phrases/frame.txt
@@ -209,3 +209,25 @@ DISPLAY x WITH FRAME f COLOR DISPLAY VALUE(5) PROMPT VALUE(3).
         value: (number_literal))
       prompt_color: (color_phrase
         value: (number_literal)))))
+
+================================================================================
+FRAME - name given by a macro
+================================================================================
+
+DISPLAY x WITH FRAME {&FRAME-NAME}.
+ENABLE x WITH FRAME {&FRAME-NAME}.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (display_statement
+    record: (identifier)
+    (frame_phrase
+      frame: (preprocessor_name
+        (identifier))))
+  (enable_statement
+    (enable_item
+      field: (identifier))
+    (frame_phrase
+      frame: (preprocessor_name
+        (identifier)))))

--- a/test/corpus/statements/create.txt
+++ b/test/corpus/statements/create.txt
@@ -346,3 +346,24 @@ CREATE TEMP-TABLE hTT[1].
     handle: (array_access
       array: (identifier)
       index: (number_literal))))
+
+================================================================================
+CREATE BUFFER - table named by a concatenation
+================================================================================
+
+CREATE BUFFER hBuf FOR TABLE qBase + pTable BUFFER-NAME pBuff.
+CREATE BUFFER hBuf FOR TABLE hT IN WIDGET-POOL "p".
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (create_statement
+    handle: (identifier)
+    table: (binary_expression
+      (identifier)
+      (identifier))
+    name: (identifier))
+  (create_statement
+    handle: (identifier)
+    table: (identifier)
+    pool: (string_literal)))

--- a/test/corpus/statements/delete.txt
+++ b/test/corpus/statements/delete.txt
@@ -200,3 +200,20 @@ DELETE OBJECT THIS-OBJECT:gData.
     name: (object_access
       left: (identifier)
       right: (identifier))))
+
+================================================================================
+DELETE WIDGET-POOL - named pool with NO-ERROR
+================================================================================
+
+DELETE WIDGET-POOL POOL NO-ERROR.
+DELETE WIDGET-POOL "mypool" NO-ERROR.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (delete_widget_pool_statement
+    pool: (identifier)
+    (no_error))
+  (delete_widget_pool_statement
+    pool: (string_literal)
+    (no_error)))

--- a/test/corpus/statements/function.txt
+++ b/test/corpus/statements/function.txt
@@ -841,3 +841,32 @@ FUNCTION f RETURNS DECIMAL PRIVATE (INPUT p AS CHARACTER) FORWARD.
         name: (identifier)
         type: (identifier)))
     (forward)))
+
+================================================================================
+FUNCTION FORWARD - unnamed parameters
+================================================================================
+
+FUNCTION SetGedDocValue RETURNS LOGICAL (INPUT INTEGER, INPUT CHARACTER) IN hRunEdit.
+FUNCTION doubler RETURNS INTEGER (INPUT INTEGER EXTENT 3) FORWARD.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (function_forward_definition
+    name: (identifier)
+    type: (identifier)
+    (parameters
+      (parameter
+        type: (identifier))
+      (parameter
+        type: (identifier)))
+    (in_phrase
+      context: (identifier)))
+  (function_forward_definition
+    name: (identifier)
+    type: (identifier)
+    (parameters
+      (parameter
+        type: (identifier)
+        size: (number_literal)))
+    (forward)))

--- a/test/corpus/statements/image.txt
+++ b/test/corpus/statements/image.txt
@@ -596,3 +596,20 @@ UPDATE animate WITH FRAME y.
       field: (identifier))
     (frame_phrase
       frame: (identifier))))
+
+================================================================================
+IMAGE DEFINITION - FILENAME as a synonym of FILE
+================================================================================
+
+DEFINE IMAGE IMAGE-1 FILENAME "ctrlf11.bmp":U SIZE 3.14 BY .67.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (image_definition
+    name: (identifier)
+    (image_phrase
+      file: (string_literal))
+    (size_phrase
+      width: (number_literal)
+      height: (number_literal))))

--- a/test/corpus/statements/on.txt
+++ b/test/corpus/statements/on.txt
@@ -534,3 +534,35 @@ END.
     (anywhere)
     (do_statement
       (body))))
+
+================================================================================
+ON - widget named by a macro
+================================================================================
+
+ON WINDOW-CLOSE OF FRAME {&FRAME-NAME}
+DO:
+END.
+
+ON CHOOSE OF BROWSE {&BROWSE-NAME}
+DO:
+END.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (on_statement
+    event: (identifier)
+    (of_phrase
+      widget: (widget_phrase
+        frame: (preprocessor_name
+          (identifier))))
+    (do_statement
+      (body)))
+  (on_statement
+    event: (identifier)
+    (of_phrase
+      widget: (widget_phrase
+        browse: (preprocessor_name
+          (identifier))))
+    (do_statement
+      (body))))


### PR DESCRIPTION
Seven commits that landed after #124 was merged — they were pushed to that branch but the merge had already taken the first eight, so they need a PR of their own. Rebased on master, **1132 corpus tests pass**, `ACTION_COUNT` 39 188 → 39 506 over both PRs.

On a 700-file sample of the AppBuilder-generated codebase, this branch takes the pass rate from **42.3% to 60.1%** and the total error count down **41%**.

### The two that carried most of it

**`AT COL 1 ROW 1`** — every other COLUMN in the grammar already accepted the abbreviation; only the AT phrase demanded the full word. One `{ offset: 3 }`, **zero change to the parse tables**, and 54 files went from failing to clean. AppBuilder writes that form in the frame phrase of every screen it generates.

**A macro alone on its line** — `{&FetchDyn}` expands to whole statements, terminator included, so none follows it and the parser inserted a MISSING node. The token already existed as `constant` in extras but sits at precedence -1 and always lost to `{`. Raising it there would have swallowed a macro ending a line inside an expression (`ASSIGN x = {&MAXVAL}` followed by another pair), so the same token is added at statement level only, where it outranks `{` and nothing else changes. That was 61 more files.

### The rest

| Fix | ACTION_COUNT |
|---|---|
| unnamed parameters in a function prototype | +22 |
| a macro naming a frame, browse or menu | +26 |
| CREATE BUFFER table as a character expression | +11 |
| FILENAME as a synonym of FILE in an image phrase | +5 |
| NO-ERROR and a quoted name on DELETE WIDGET-POOL | +2 |

Two of these are worth a note.

The **function prototype** commit shares its parameter rule with the definition on purpose. The two forms are identical up to the closing parenthesis and diverge only at the token after it, so LR(1) cannot choose a rule at `(`. The cost is that an unnamed parameter is also accepted in a definition, where ABL rejects it. Splitting them cleanly needs a declared conflict.

The **macro-named widget** commit deliberately leaves one position out. In an expression, `x IN FRAME {&F}` goes through `widget_qualified_name`, which sits in `_primary_expression` and is reachable from everywhere: widening it there cost **532 actions and 204 large states** for that one form, against 26 for everything else in the commit. It stays unsupported until it earns that.

### Still open from #124: `conflicts`

You merged before this got an answer, so I am repeating it — it is now the single largest cause left, 61 files in the sample.

`ASSIGN FRAME F1:SCROLLABLE = FALSE.` fails. After `ASSIGN` shifts `FRAME`, two items are live:

```
__assign_input_body -> FRAME . identifier ...   (the frame clause)
_widgets            -> FRAME .                  (reduce, towards object_access)
```

The reduce/shift choice sees only the identifier, and both alternatives accept an identifier there. It takes two tokens — the identifier, then whether a `:` follows — to tell `ASSIGN FRAME F1 fld = 1.` from `ASSIGN FRAME F1:attr = FALSE.`

Precedence cannot help: whichever side wins, the other form breaks. Associativity does not apply. Left-factoring means reducing `FRAME identifier` to one shared nonterminal before knowing which it is, which changes the node shape of the existing `ASSIGN FRAME f fld` form and its corpus expectation. That leaves a declared conflict.

Your AGENTS.md asks for confirmation first, so I have not written one. Would you take it there? If the answer is no, the frame-attribute form simply stays unsupported and I will stop looking at it.

### Windows build, unrelated

Building on Windows now fails intermittently with `fatal error C1060: out of heap space` in the MSVC optimizing pass, at 113 MiB of `parser.c`. It is memory pressure rather than a hard ceiling — the same file compiles when the machine is idle, and `-Od` makes it reliable. Worth knowing since you ship Windows prebuilds and the margin is thin.
