### PR TITLE
grammar: DATA-RELATION field order, VIEW/HIDE IN WINDOW, RADIO-BUTTONS null, a call before IN, keyword abbreviations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -134,6 +134,13 @@ export default grammar({
     // `DYNAMIC-FUNCTION(pNom IN h)` has the same ambiguity after a bare name,
     // before the argument expression has reduced to __argument_body.
     [$.__argument_in_handle, $.__widget_qualified_name_separator],
+    // `DYNAMIC-FUNCTION(ENTRY(2,c) IN h)` against
+    // `trashcan:LOAD-IMAGE("a") IN FRAME y` -- on the IN after a call the
+    // parser must choose between the argument's own IN clause and a widget
+    // qualifier. A precedence was tried first and cannot resolve it: it fixes
+    // one reading for every call, and only the token after IN tells them apart.
+    [$.__argument_body, $.widget_qualified_name, $._primary_expression],
+    [$.widget_qualified_name, $._primary_expression],
     // `a::c` off a bare name is a scoped_name; the object-access tail reads the
     // same `::` for the receivers scoped_name cannot take, so on that token
     // both are alive and only the receiver settles it -- which the parser has

--- a/grammar.js
+++ b/grammar.js
@@ -126,11 +126,6 @@ export default grammar({
     // parser must choose between the trigger's argument list and a call on the
     // context that precedes it. Both are alive at that token.
     [$.__on_context_value, $.function_call],
-    // `DYNAMIC-FUNCTION("f" IN h:PARENT)` -- on the IN after an argument the
-    // parser must choose between the argument's own IN clause and a widget
-    // qualifier, which expects IN WINDOW. Both are alive at that token and only
-    // what follows settles it, so it is decided at parse time.
-    [$.__argument_body, $.__widget_qualified_name_separator],
     // `DYNAMIC-FUNCTION(pNom IN h)` has the same ambiguity after a bare name,
     // before the argument expression has reduced to __argument_body.
     [$.__argument_in_handle, $.__widget_qualified_name_separator],

--- a/grammar.js
+++ b/grammar.js
@@ -117,6 +117,11 @@ export default grammar({
     [$.__disable_item, $.function_call],
     // Field / Column / Handle can be just an identifier
     [$.__widget_entry],
+    // VIEW/HIDE only: a bare name before IN WINDOW cannot be told apart from
+    // one before IN FRAME/IN BROWSE with a single token of lookahead; only
+    // what follows IN settles it. Scoped to its own symbol so the fork does
+    // not reach the shared __widget_entry/__widget_handle used elsewhere.
+    [$.__view_hide_widget_ref],
     // `ON … PERSISTENT RUN chx IN THIS-PROCEDURE (hb).` -- on the `(` the
     // parser must choose between the trigger's argument list and a call on the
     // context that precedes it. Both are alive at that token.

--- a/grammar/core/common.js
+++ b/grammar/core/common.js
@@ -21,7 +21,16 @@ export default ({ kw }) => ({
       seq(field("except", $._identifier_or_qualified_name), optional($._except_name_list)),
     ),
   _frame_phrases: ($) => seq($.frame_phrase, optional($.frame_phrase)),
-  _widget_phrases: ($) => prec.right(seq($.widget_phrase, optional($._widget_phrases))),
+  // VIEW and HIDE are the only users, and both admit a trailing IN WINDOW that
+  // the shared widget_phrase cannot be told apart from IN FRAME with a single
+  // token of lookahead, hence the statement-local variant.
+  _widget_phrases: ($) =>
+    prec.right(
+      seq(
+        alias($.__view_hide_widget_phrase, $.widget_phrase),
+        optional($._widget_phrases),
+      ),
+    ),
   _format_phrases: ($) => prec.right(seq($.format_phrase, optional($._format_phrases))),
   _text_fields: ($) =>
     prec.right(

--- a/grammar/phrases/format.js
+++ b/grammar/phrases/format.js
@@ -172,6 +172,7 @@ export default ({ kw }) => ({
       $.number_literal,
       alias($._signed_number_literal, $.number_literal),
       $.boolean_literal,
+      $.null_literal,
     ),
 
   __format_combo_box_phrase: ($) =>

--- a/grammar/phrases/widget.js
+++ b/grammar/phrases/widget.js
@@ -54,4 +54,44 @@ export default ({ kw }) => ({
       kw("TARGET-PROCEDURE"),
       kw("THIS-PROCEDURE"),
     ),
+
+  // VIEW/HIDE-only variant of widget_phrase: a bare name here can be followed
+  // by IN WINDOW (not part of the entry/handle choice), which FRAME/BROWSE
+  // cannot settle with one token of lookahead. Kept as its own symbols
+  // (aliased back to widget_phrase) so the resulting GLR fork stays local to
+  // VIEW/HIDE instead of reaching every widget_phrase call site.
+  __view_hide_widget_phrase: ($) =>
+    choice(
+      seq(kw("FRAME", { offset: 4 }), field("frame", $.__widget_name)),
+      seq(kw("BROWSE"), field("browse", $.__widget_name)),
+      $.__view_hide_widget_ref,
+      seq(choice(kw("MENU"), kw("SUB-MENU")), field("menu", $.__widget_name)),
+    ),
+  __view_hide_widget_ref: ($) =>
+    choice(
+      seq(
+        kw("FIELD"),
+        field("field", $._identifier_or_array_access),
+        optional(seq(kw("IN"), kw("FRAME", { offset: 4 }), field("frame", $.__widget_name))),
+      ),
+      seq(
+        field("field", $._identifier_or_array_access),
+        seq(kw("IN"), kw("FRAME", { offset: 4 }), field("frame", $.__widget_name)),
+      ),
+      seq(
+        field("field", $.array_access),
+        optional(seq(kw("IN"), kw("FRAME", { offset: 4 }), field("frame", $.__widget_name))),
+      ),
+      seq(
+        field("column", $._identifier_or_array_access),
+        seq(kw("IN"), kw("BROWSE"), field("browse", $.__widget_name)),
+      ),
+      seq(
+        kw("MENU-ITEM"),
+        field("item", $._identifier_or_qualified_name),
+        optional(seq(kw("IN"), kw("MENU"), field("menu", $.__widget_name))),
+      ),
+      field("system_handle", alias($.__widget_system_handle, $.system_handle)),
+      field("handle", choice($._identifier_or_qualified_name, $.preprocessor_name)),
+    ),
 });

--- a/grammar/precedences/widget.js
+++ b/grammar/precedences/widget.js
@@ -39,8 +39,4 @@ export default ($) => [
   // Example: MENU-ITEM m1:SENSITIVE IN MENU mymenu = TRUE.
   // Reference: Widget phrase.
   [$.widget_qualified_name, $.object_access],
-  // Purpose: prefer widget-qualified name when IN <widget> follows identifier.
-  // Example: x IN FRAME f.
-  // Reference: Widget phrase.
-  [$.widget_qualified_name, $._primary_expression],
 ];

--- a/grammar/precedences/widget.js
+++ b/grammar/precedences/widget.js
@@ -20,6 +20,10 @@ export default ($) => [
   // Example: ON CHOOSE OF myFunc().
   // Reference: Widget phrase.
   [$.function_call, $.__widget_handle],
+  // Purpose: same as above, for the VIEW/HIDE-only widget-ref variant.
+  // Example: VIEW myFunc().
+  // Reference: Widget phrase; VIEW statement; HIDE statement.
+  [$.function_call, $.__view_hide_widget_ref],
   // Purpose: a name that IN FRAME, IN BROWSE or MENU-ITEM qualifies is an
   // entry; a name on its own can no longer match the entry rule, so reading
   // the entry first keeps the qualifier attached without stealing bare names.

--- a/grammar/statements/dataset.js
+++ b/grammar/statements/dataset.js
@@ -9,16 +9,27 @@ export default ({ kw }) => ({
       kw("DATA-RELATION"),
       $.__dataset_relation_head,
       optional(
-        seq(
-          kw("RELATION-FIELDS"),
-          "(",
-          $.__dataset_relation_field_pair,
-          optional($.__dataset_relation_field_pair_tail),
-          ")",
+        choice(
+          seq($.__dataset_relation_fields, optional($.__dataset_relation_qualifiers)),
+          seq($.__dataset_relation_qualifiers, optional($.__dataset_relation_fields)),
         ),
       ),
-      optional(alias(kw("REPOSITION"), $.reposition)),
-      optional($.__dataset_data_relation_after_reposition),
+    ),
+  __dataset_relation_fields: ($) =>
+    seq(
+      kw("RELATION-FIELDS"),
+      "(",
+      $.__dataset_relation_field_pair,
+      optional($.__dataset_relation_field_pair_tail),
+      ")",
+    ),
+  __dataset_relation_qualifiers: ($) =>
+    choice(
+      seq(
+        alias(kw("REPOSITION"), $.reposition),
+        optional($.__dataset_data_relation_after_reposition),
+      ),
+      $.__dataset_data_relation_after_reposition,
     ),
   __dataset_relation_field_pair: ($) =>
     seq(field("parent_field", $.identifier), ",", field("child_field", $.identifier)),

--- a/grammar/statements/disconnect.js
+++ b/grammar/statements/disconnect.js
@@ -3,7 +3,7 @@ export default ({ kw }) => ({
 
   __disconnect_prefix: ($) =>
     seq(
-      kw("DISCONNECT"),
+      kw("DISCONNECT", { offset: 6 }),
       choice(
         seq(kw("VALUE"), "(", field("database", $._expression), ")"),
         field("database", $._identifier_or_string_literal),

--- a/grammar/statements/put-key-value.js
+++ b/grammar/statements/put-key-value.js
@@ -3,7 +3,7 @@ export default ({ kw }) => ({
 
   __put_key_value_prefix: ($) =>
     seq(
-      kw("PUT-KEY-VALUE"),
+      kw("PUT-KEY-VALUE", { offset: 11 }),
       choice(
         seq(
           kw("SECTION"),

--- a/test/corpus/phrases/radio-set.txt
+++ b/test/corpus/phrases/radio-set.txt
@@ -28,3 +28,22 @@ DEFINE VARIABLE w AS INTEGER VIEW-AS RADIO-SET HORIZONTAL EXPAND SIZE 30 BY 3 RA
         label: (string_literal)
         value: (number_literal)
         tooltip: (string_literal)))))
+
+================================================================================
+VIEW-AS RADIO-SET - Unknown value button
+================================================================================
+
+DEFINE VARIABLE v AS INTEGER VIEW-AS RADIO-SET RADIO-BUTTONS "A", 1, "Unknown", ?.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (variable_definition
+    name: (identifier)
+    type: (identifier)
+    (view_as_phrase
+      (radio_set_phrase
+        label: (string_literal)
+        value: (number_literal)
+        label: (string_literal)
+        value: (null_literal)))))

--- a/test/corpus/statements/dataset.txt
+++ b/test/corpus/statements/dataset.txt
@@ -296,3 +296,37 @@ DEFINE DATASET ds2 FOR tt, b
       parent_field: (identifier)
       child_field: (identifier)
       (nested))))
+
+================================================================================
+DATASET - RELATION-FIELDS after NESTED
+================================================================================
+
+DEFINE DATASET ds FOR tt, b
+  DATA-RELATION FOR tt, b NESTED RELATION-FIELDS (k, k).
+DEFINE DATASET ds2 FOR tt, b
+  DATA-RELATION FOR tt, b NOT-ACTIVE RECURSIVE RELATION-FIELDS (k, k).
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (dataset_definition
+    name: (identifier)
+    table: (identifier)
+    table: (identifier)
+    (data_relation
+      parent_buffer: (identifier)
+      child_buffer: (identifier)
+      (nested)
+      parent_field: (identifier)
+      child_field: (identifier)))
+  (dataset_definition
+    name: (identifier)
+    table: (identifier)
+    table: (identifier)
+    (data_relation
+      parent_buffer: (identifier)
+      child_buffer: (identifier)
+      (not_active)
+      (recursive)
+      parent_field: (identifier)
+      child_field: (identifier))))

--- a/test/corpus/statements/disconnect.txt
+++ b/test/corpus/statements/disconnect.txt
@@ -67,3 +67,19 @@ DISCONNECT mydb NO-ERROR.
   (disconnect_statement
     database: (identifier)
     (no_error)))
+
+================================================================================
+DISCONNECT - abbreviated keyword
+================================================================================
+
+DISCON mydb.
+DISCONN mydb NO-ERROR.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (disconnect_statement
+    database: (identifier))
+  (disconnect_statement
+    database: (identifier)
+    (no_error)))

--- a/test/corpus/statements/function.txt
+++ b/test/corpus/statements/function.txt
@@ -1052,3 +1052,62 @@ END FUNCTION.
     name: (identifier)
     type: (identifier)
     (parameters)))
+
+================================================================================
+DYNAMIC-FUNCTION - a call as the function name before IN
+================================================================================
+
+x = DYNAMIC-FUNCTION(ENTRY(2,c) IN h, a).
+y = DYNAMIC-FUNCTION(ENTRY(2,p,"|") IN WIDGET-HANDLE(ENTRY(1,p,"|")), s).
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (assignment_statement
+    left: (identifier)
+    operator: (assignment_operator)
+    right: (function_call
+      function: (identifier)
+      (arguments
+        (argument
+          name: (function_call
+            function: (identifier)
+            (arguments
+              (argument
+                name: (number_literal))
+              (argument
+                name: (identifier))))
+          in_handle: (identifier))
+        (argument
+          name: (identifier)))))
+  (assignment_statement
+    left: (identifier)
+    operator: (assignment_operator)
+    right: (function_call
+      function: (identifier)
+      (arguments
+        (argument
+          name: (function_call
+            function: (identifier)
+            (arguments
+              (argument
+                name: (number_literal))
+              (argument
+                name: (identifier))
+              (argument
+                name: (string_literal))))
+          in_handle: (function_call
+            function: (identifier)
+            (arguments
+              (argument
+                name: (function_call
+                  function: (identifier)
+                  (arguments
+                    (argument
+                      name: (number_literal))
+                    (argument
+                      name: (identifier))
+                    (argument
+                      name: (string_literal))))))))
+        (argument
+          name: (identifier))))))

--- a/test/corpus/statements/hide.txt
+++ b/test/corpus/statements/hide.txt
@@ -159,3 +159,18 @@ HIDE select-1 select-2 IN FRAME f1.
     (widget_phrase
       field: (identifier)
       frame: (identifier))))
+
+================================================================================
+HIDE - a bare widget name IN WINDOW
+================================================================================
+
+HIDE c-win IN WINDOW w1.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (hide_statement
+    (widget_phrase
+      handle: (identifier))
+    (in_window_phrase
+      window: (identifier))))

--- a/test/corpus/statements/put-key-value.txt
+++ b/test/corpus/statements/put-key-value.txt
@@ -109,3 +109,20 @@ PUT-KEY-VALUE FONT 2.
   (put_key_value_statement)
   (put_key_value_statement
     number: (number_literal)))
+
+================================================================================
+PUT-KEY-VALUE - abbreviated keyword
+================================================================================
+
+PUT-KEY-VAL SECTION "general" KEY "theme" VALUE "dark".
+PUT-KEY-VALU COLOR 1.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (put_key_value_statement
+    section: (string_literal)
+    key: (string_literal)
+    value: (string_literal))
+  (put_key_value_statement
+    number: (number_literal)))

--- a/test/corpus/statements/view.txt
+++ b/test/corpus/statements/view.txt
@@ -170,3 +170,18 @@ VIEW Thdimm Thdimam.
       handle: (identifier))
     (widget_phrase
       handle: (identifier))))
+
+================================================================================
+VIEW - a bare widget name IN WINDOW
+================================================================================
+
+VIEW c-win IN WINDOW w1.
+
+--------------------------------------------------------------------------------
+
+(source_code
+  (view_statement
+    (widget_phrase
+      handle: (identifier))
+    (in_window_phrase
+      window: (identifier))))


### PR DESCRIPTION
Six defects found on a production ABL corpus, each with its own commit, corpus test, and parser delta. Rebased onto master.

## Where it stands

| | base | head | delta |
|---|---:|---:|---:|
| ACTION_COUNT | 39 286 | **39 358** | +72 |
| STATE_COUNT | 34 379 | **34 448** | +69 |
| LARGE_STATE_COUNT | 16 457 | **16 487** | +30 |
| `parser.c` | 121.69 MiB | **122.01 MiB** | +0.33 MiB |

**1275 corpus tests pass, none fail.**

## What is in it

- **`DATA-RELATION` field order.** `RELATION-FIELDS` was only accepted before `REPOSITION`/`NESTED`/`NOT-ACTIVE`/`RECURSIVE`, never after — the compiler allows both orders. Made the two option groups order-independent.
- **`VIEW`/`HIDE <widget> IN WINDOW <handle>`.** A bare widget name before `IN WINDOW` couldn't be told apart from one before `IN FRAME`/`IN BROWSE` with one token of lookahead. The official "Widget phrase" reference (used by APPLY/ON/WAIT-FOR) has no `WINDOW` branch at all — `IN WINDOW` is a trailing clause of the statement, never part of the phrase — so this scopes the GLR fork to a VIEW/HIDE-only copy of the ambiguous branches (aliased back to `widget_phrase`) instead of the shared symbols, which explode combinatorially if forced to conflict globally.
- **`?` in a `RADIO-BUTTONS` list.** Accepted in a `VIEW-AS RADIO-SET` variable definition but not inside a `DEFINE FRAME` widget list. Added `null_literal` to the shared value choice.
- **A call as the function name before `IN`.** `DYNAMIC-FUNCTION(ENTRY(2,c) IN h)` failed the same way `trashcan:LOAD-IMAGE("a") IN FRAME y` succeeds — both are calls followed by `IN`, and a static precedence fixed the widget reading for every call. Replaced with the two conflicts tree-sitter names for the same states; the reference gives the refused form as canonical (`function-name` is "A CHARACTER expression", and the entry's own example passes an array element, not a literal).
- **Abbreviated `DISCONNECT`/`PUT-KEY-VALUE`.** ABL accepts `DISCON…`/`PUT-KEY-VAL…`; the grammar only knew the full keywords. Both cost nothing measurable.
- **One dead conflict removed.** `__argument_body`/`__widget_qualified_name_separator` was flagged unnecessary by every `generate` run; dropping it changes no count and no byte of `parser.c`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_015LUhCsQrLPRnmi1An3JvQL