### PR TITLE
build: compile with ClangCL on Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -23,7 +23,12 @@
           "cflags_c": [
             "-std=c11",
           ],
-        }, { # OS == "win"
+        }, { # OS == "win" — MSVC cl.exe hits C1060 (out of compiler heap) on the
+             # generated src/parser.c once it grows past ~100 MB (measured on
+             # feat/appbuilder-round4, 147 MB / 38 897 states). ClangCL handles the
+             # same translation unit without the internal heap limit; it accepts the
+             # same /std:c11 /utf-8 flags below since it is MSVC-compatible.
+          "msbuild_toolset": "ClangCL",
           "cflags_c": [
             "/std:c11",
             "/utf-8",


### PR DESCRIPTION
MSVC cl.exe hits C1060 (out of compiler heap) on the generated src/parser.c once it grows past ~100 MB. ClangCL handles the same translation unit without the internal heap limit, and is MSVC-compatible so the existing /std:c11 /utf-8 flags still apply.

Unrelated to any grammar change — independent of #129.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_015LUhCsQrLPRnmi1An3JvQL